### PR TITLE
F2P-34 | Sort news posts by `datePosted` DESC

### DIFF
--- a/src/components/atoms/NewsAndUpdates/NewsAndUpdates.tsx
+++ b/src/components/atoms/NewsAndUpdates/NewsAndUpdates.tsx
@@ -12,6 +12,7 @@ import {
 } from './NewsAndUpdates.styled'
 import { NewsPost } from './NewsAndUpdates.d'
 import { getImageUrlFromBase64 } from '@helpers/base64'
+import { getPrettyDateStringFromISOString } from '@/lib/helpers/date/date'
 
 // Example is OSRS website: https://oldschool.runescape.com
 // Using MUI component sample code: https://mui.com/material-ui/react-list/``
@@ -34,12 +35,13 @@ const NewsAndUpdates = () => {
 
   if (!newsPosts || !Array.isArray(newsPosts) || !newsPosts?.some(newsPost => newsPost.title)) return null
 
-  // TODO: Handle this as a different Jira ticket. You're just trying to get the submit form 100% in this branch!
-  // newsPosts.sort((a, b) => {
-  //   // Turn your strings into dates, and then subtract them
-  //   // to get a value that is either negative, positive, or zero.
-  //   return new Date(b.datePosted) - new Date(a.datePosted)
-  // })
+  // Make latest posts appear first
+  newsPosts.sort((a, b) => {
+    const aDatePosted = new Date(a.datePosted)
+    const bDatePosted = new Date(b.datePosted)
+
+    return bDatePosted.getTime() - aDatePosted.getTime()
+  })
 
   return (
     <ContentBlock>
@@ -57,7 +59,7 @@ const NewsAndUpdates = () => {
                 }
                 secondary={
                   <>
-                    <Typography variant="body">{newsPost.datePosted}</Typography>
+                    <Typography variant="body">{getPrettyDateStringFromISOString(newsPost.datePosted)}</Typography>
                     <Typography variant="body" color="black">{newsPost.body}</Typography>
                   </>
                 }

--- a/src/lib/helpers/date/date.ts
+++ b/src/lib/helpers/date/date.ts
@@ -16,3 +16,19 @@ export const getDateString = (date: Date) => {
 
   return `${month} ${day}, ${year}`
 }
+
+export const getPrettyDateStringFromISOString = (dateString: string) => {
+  const date = new Date(dateString)
+
+  const month = date.toLocaleString('default', { month: 'long' });
+  const dayInt = date.getDate()
+  const day = `${dayInt}${nth(dayInt)}`
+  const year = date.getFullYear()
+
+  // Add time, not in military
+  const hours = date.getHours() - 12
+  const minutes = date.getMinutes()
+  const period = date.getHours() >= 12? 'PM' : 'AM'
+
+  return `${month} ${day}, ${year} ${hours}:${minutes} ${period}`
+}

--- a/src/pages/admin/newsPostForm/index.tsx
+++ b/src/pages/admin/newsPostForm/index.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react'
 import axios from 'axios';
 import { convertBlobToBase64String } from '@helpers/base64'
-import { getDateString } from '@/lib/helpers/date/date';
 import { StyledForm, Field, SubmitArea, SubmitButton, SubmitMessage } from './NewsPostForm.styled'
 import Typography from '@mui/material/Typography'
 
@@ -45,7 +44,7 @@ const NewsPostForm = () => {
       image: imageBase64,
       alt,
       title,
-      datePosted: getDateString(new Date()),
+      datePosted: new Date(),
       body
     })
     .then((response) => {


### PR DESCRIPTION
# What's Changed
- Changed `NewsPostForm` to submit current date as ISO string
- Updated `NewsAndUpdates` component to print date in the string format we were inserting it
- Sorted news posts so most recent ones appear at the top
- Added time to date strings (so time now appears on the website)

![image](https://user-images.githubusercontent.com/17816529/235808930-684bb5ac-ceb4-44b9-adf6-2590690ee496.png)

# Notes
- While testing this, I deleted all newspost records (and their associated images) that had the wrong date format.
- The time shown in the Latest News module seems to work regardless of the user's timezone. 
![image](https://user-images.githubusercontent.com/17816529/235809349-669be442-070d-426e-a90f-424bd24f6dbb.png)
