### PR TITLE
F2P-36 | Long news posts don't appear correctly

### DIFF
--- a/src/components/atoms/NewsAndUpdates/NewsAndUpdates.styled.ts
+++ b/src/components/atoms/NewsAndUpdates/NewsAndUpdates.styled.ts
@@ -17,6 +17,10 @@ export const NewsPostListItem = styled(ListItem)(
     flex-wrap: wrap;
     padding: 0;
     margin: 10px 0 20px;
+
+    ${theme.breakpoints.up('tablet')} {
+      flex-wrap: nowrap;
+    }
   `
 )
 


### PR DESCRIPTION
# What's Changed
- Fixed issue with news post text breaking to a new line on tablet & desktop if too long