### PR TITLE
F2P-40 | Latest News section should probably only show X posts and then a read more link

### DIFF
--- a/src/components/atoms/NewsAndUpdates/NewsAndUpdates.styled.ts
+++ b/src/components/atoms/NewsAndUpdates/NewsAndUpdates.styled.ts
@@ -4,9 +4,12 @@ import List from '@mui/material/List'
 import ListItem from '@mui/material/ListItem'
 import ListItemAvatar from '@mui/material/ListItemAvatar'
 import { Typography } from '@mui/material'
+import Link from 'next/link'
 
 export const NewsPostList = styled(List)(
   () => css`
+    margin-top: 20px;
+    
     hr:last-child {
       display: none;
     }
@@ -50,4 +53,16 @@ export const NewsPostImage = styled('img')(
 
 export const NewsPostTitle = styled(Typography)`
   font-weight: 600;
+`
+
+export const ReadMoreLink = styled(Link)`
+  text-decoration: none;
+  color: unset;
+  display: block;
+  width: fit-content;
+  margin: 0 auto;
+
+  :hover {
+    text-decoration: underline;
+  }
 `

--- a/src/components/atoms/NewsAndUpdates/NewsAndUpdates.tsx
+++ b/src/components/atoms/NewsAndUpdates/NewsAndUpdates.tsx
@@ -8,20 +8,26 @@ import {
   NewsPostAvatar,
   NewsPostImage,
   NewsPostTitle,
+  ReadMoreLink,
 } from './NewsAndUpdates.styled'
 import { NewsPost } from './NewsAndUpdates.d'
 import { getImageUrlFromBase64 } from '@helpers/base64'
 import { getPrettyDateStringFromISOString } from '@helpers/date/date'
 
-// Example is OSRS website: https://oldschool.runescape.com
-// Using MUI component sample code: https://mui.com/material-ui/react-list/
-const NewsAndUpdates = () => {
-  console.log('NewsandUpdates renders')
+interface NewsAndUpdatesProps {
+  heading: string;
+  /** Limits the number of news posts to show. */
+  limit?: number;
+  showReadMore?: boolean;
+}
 
+const NewsAndUpdates = (props: NewsAndUpdatesProps) => {
+  const { heading, limit, showReadMore } = props;
   const [newsPosts, setNewsPosts] = useState<NewsPost[]|undefined>(undefined)
+
   const fetchNewsPosts = () => {
     console.log('fetchNewsPosts should only be called once', newsPosts)
-    axios.get('/api/getNewsPosts')
+    axios.get(`/api/getNewsPosts${limit ? `?limit=${limit}` : ''}`)
       .then((response) => {
         setNewsPosts(response.data)
       })
@@ -53,7 +59,7 @@ const NewsAndUpdates = () => {
 
   return (
     <ContentBlock isHomepage>
-      <Typography variant="h2">Latest News & Updates</Typography>
+      <Typography variant="h2">{heading}</Typography>
       <NewsPostList disablePadding>
         {newsPosts.map((newsPost : NewsPost) => (
           <div key={newsPost.id}>
@@ -78,6 +84,11 @@ const NewsAndUpdates = () => {
           </div>
         ))}
       </NewsPostList>
+      {showReadMore && newsPosts.length >= 3 && (
+        <ReadMoreLink href='/news'>
+          <Typography variant="body">Read more</Typography>
+        </ReadMoreLink>
+      )}
     </ContentBlock>
   )
 }

--- a/src/components/molecules/MainNavigation/MainNavigation.tsx
+++ b/src/components/molecules/MainNavigation/MainNavigation.tsx
@@ -13,6 +13,10 @@ const MainNavigation = () => {
       text: 'About'
     },
     {
+      path: '/news',
+      text: 'News',
+    },
+    {
       path: '/how-to-play',
       text: 'How to Play',
     },

--- a/src/pages/api/getNewsPosts/index.ts
+++ b/src/pages/api/getNewsPosts/index.ts
@@ -7,10 +7,14 @@ const handler = async (
   res: NextApiResponse<NewsPost>
 ) => {
   try {
-    let list: NewsPost[] = []
+    const list: NewsPost[] = []
+    const limit = req?.query?.limit
     const query = `SELECT np.id, i.image, i.alt, np.title, np.datePosted, np.body
-    FROM newsposts np
-    LEFT OUTER JOIN images i ON np.image = i.id`
+      FROM newsposts np
+      LEFT OUTER JOIN images i ON np.image = i.id
+      ORDER BY np.datePosted DESC
+      ${limit ? `LIMIT ${limit}` : ''}`
+
     const response: Array<any> | { error: unknown } = await queryWebsiteDatabase(query)
     
     if (response instanceof Array) {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -17,7 +17,7 @@ const Homepage = () => (
         For more information, check out the <Link href="/about">About page</Link>.
       </SectionBody>
     </ContentBlock>
-    <NewsAndUpdates />
+    <NewsAndUpdates heading='Latest News & Updates' limit={3} showReadMore />
     <ContentBlock isHomepage>
       <Typography variant="h2">Join the Community</Typography>
       <SectionBody variant="body">

--- a/src/pages/news/index.tsx
+++ b/src/pages/news/index.tsx
@@ -1,0 +1,10 @@
+import { ContentBlock } from "@atoms/ContentBlock";
+import { NewsAndUpdates } from "@atoms/NewsAndUpdates";
+
+const News = () => (
+  <ContentBlock topMargin={20}>
+    <NewsAndUpdates heading="News" />
+  </ContentBlock>
+)
+
+export default News


### PR DESCRIPTION
- Added News page
- Added read more link to `NewsAndUpdates` via prop
- Added limit parameter to `getNewsPosts` API call
- Made heading of `NewsAndUpdates` configurable via prop
- Tweaked spacing below `NewsAndUpdates` heading