### PR TITLE
F2P-46 | Database-dependent components do not appear until 3-4 seconds after page load

### DIFF
--- a/src/components/atoms/OnlinePlayers/OnlinePlayers.tsx
+++ b/src/components/atoms/OnlinePlayers/OnlinePlayers.tsx
@@ -1,8 +1,10 @@
 import axios from 'axios'
 import { useEffect, useState } from 'react'
 import { PlayersOnlineBox, PlayersOnlineMessage, OnlineCount } from './OnlinePlayers.styled'
+import { Spinner } from '@molecules/Spinner'
 
 const OnlinePlayers = () => {
+  const [isLoading, setIsLoading] = useState(true)
   const [playerCount, setPlayerCount] = useState<number|undefined>(undefined)
   const verb = playerCount === 1 ? 'is' : 'are'
 
@@ -11,6 +13,7 @@ const OnlinePlayers = () => {
       axios.get('/api/getOnlinePlayerCount')
         .then((response) => {
           setPlayerCount(response.data)
+          setIsLoading(false)
         })
         .catch((error : string) => error)
     }
@@ -18,7 +21,14 @@ const OnlinePlayers = () => {
     if (playerCount === undefined) {
       fetchOnlinePlayerCount()
     }
-  }, [playerCount])
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  if (isLoading) {
+    return (
+      <Spinner />
+    )
+  }
 
   if (playerCount != 0 && !playerCount) return null
 

--- a/src/components/molecules/Spinner/Spinner.tsx
+++ b/src/components/molecules/Spinner/Spinner.tsx
@@ -1,0 +1,10 @@
+import { ContentBlock } from "@atoms/ContentBlock"
+import { CircularProgress } from "@mui/material"
+
+const Spinner = () => (
+  <ContentBlock>
+    <CircularProgress color='success' />
+  </ContentBlock>
+)
+
+export default Spinner

--- a/src/components/molecules/Spinner/index.ts
+++ b/src/components/molecules/Spinner/index.ts
@@ -1,0 +1,1 @@
+export { default as Spinner } from './Spinner'

--- a/src/components/organisms/NewsAndUpdates/NewsAndUpdates.tsx
+++ b/src/components/organisms/NewsAndUpdates/NewsAndUpdates.tsx
@@ -5,6 +5,7 @@ import { ContentBlock } from '@atoms/ContentBlock'
 import { NewsPostList, ViewAllNewsLink } from './NewsAndUpdates.styled'
 import { NewsPost } from '@globalTypes/NewsPost'
 import { NewsPostListItem } from '@molecules/NewsPostListItem'
+import { Spinner } from '@molecules/Spinner'
 
 interface NewsAndUpdatesProps {
   heading: string
@@ -15,6 +16,7 @@ interface NewsAndUpdatesProps {
 
 const NewsAndUpdates = (props: NewsAndUpdatesProps) => {
   const { heading, limit, showViewAllButton } = props
+  const [isLoading, setIsLoading] = useState(true)
   const [newsPosts, setNewsPosts] = useState<NewsPost[]|undefined>(undefined)
 
   useEffect(() => {
@@ -22,6 +24,7 @@ const NewsAndUpdates = (props: NewsAndUpdatesProps) => {
       axios.get(`/api/getNewsPosts${limit ? `?limit=${limit}` : ''}`)
         .then((response) => {
           setNewsPosts(response.data)
+          setIsLoading(false)
         })
         .catch((error : string) => error)
     }
@@ -29,7 +32,14 @@ const NewsAndUpdates = (props: NewsAndUpdatesProps) => {
     if (newsPosts === undefined) {
       fetchNewsPosts()
     }
-  }, [newsPosts, limit])
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  if (isLoading) {
+    return (
+      <Spinner />
+    )
+  }
 
   if (!newsPosts || !Array.isArray(newsPosts) || !newsPosts?.some(newsPost => newsPost.title)) return null
 

--- a/src/pages/news/post/[id]/index.tsx
+++ b/src/pages/news/post/[id]/index.tsx
@@ -1,26 +1,38 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
 import axios from 'axios'
 import { ContentBlock } from '@atoms/ContentBlock'
 import { NewsPost } from '@globalTypes/NewsPost'
 import { NewsPostDetailItem } from '@atoms/NewsPostDetailItem'
+import { Spinner } from '@molecules/Spinner'
 
 const NewsPostDetail = () => {
-  const { query } = useRouter();
+  const { query } = useRouter()
+  const [isLoading, setIsLoading] = useState(true)
   const [newsPost, setNewsPost] = useState<NewsPost|undefined>(undefined)
 
-  const fetchNewsPosts = () => {
-    axios.get(`/api/getNewsPosts${query?.id ? `?id=${query.id}` : ''}`)
-      .then((response) => {
-        if (response?.data?.length === 1) {
-          setNewsPost(response.data[0])
-        }
-      })
-      .catch((error : string) => error)
-  }
+  useEffect(() => {
+    const fetchNewsPost = () => {
+      axios.get(`/api/getNewsPosts${query?.id ? `?id=${query.id}` : ''}`)
+        .then((response) => {
+          if (response?.data?.length === 1) {
+            setNewsPost(response.data[0])
+            setIsLoading(false)
+          }
+        })
+        .catch((error : string) => error)
+    }
+  
+    if (newsPost === undefined) {
+      fetchNewsPost()
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [query])
 
-  if (newsPost === undefined) {
-    fetchNewsPosts()
+  if (isLoading) {
+    return (
+      <Spinner />
+    )
   }
 
   if (!newsPost?.title) return null


### PR DESCRIPTION
# What's Changed

- Added loading spinner for database-result components
- Reduced unnecessary `useEffect` calls