### PR TITLE
F2P-61 | New accounts created via the website cannot get past the customization screen

### DIFF
--- a/src/helpers/apiHandler.ts
+++ b/src/helpers/apiHandler.ts
@@ -4,11 +4,12 @@ import { OkPacket } from 'mysql'
 import { ErrorResult } from '@globalTypes/Database/ErrorResult'
 import { User } from '@globalTypes/User'
 
-/** Helper for updating website records. */
-export const handleUpdate = async (
+/** Helper for manipulating (UPDATEing or INSERTing) database records. */
+export const handleManipulate = async (
   databaseType: 'website' | 'game',
   sqlQuery: string,
   res: NextApiResponse<User>,
+  returnLastInsertedId?: boolean,
 ): Promise<void> => {
   try {
     const queryResponse: OkPacket | ErrorResult = await queryDatabase(databaseType, sqlQuery)
@@ -26,7 +27,7 @@ export const handleUpdate = async (
     // Return a JSON result indicating success
     res.statusCode = 200
     res.setHeader('Content-Type', 'application/json')
-    res.end(JSON.stringify(queryResponse?.affectedRows))
+    res.end(JSON.stringify(returnLastInsertedId ? queryResponse?.insertId : queryResponse?.affectedRows))
   } catch (error) {
     console.log('An error occurred in the API handler: ', error)
     res.statusCode = 500

--- a/src/pages/account/game-accounts/create/index.tsx
+++ b/src/pages/account/game-accounts/create/index.tsx
@@ -67,7 +67,17 @@ const CreateGameAccount = () => {
         })
         .then(response => {
           if (typeof response?.data === 'number') {
-            redirectTo(`/account/game-accounts/create/success?accountName=${accountName}`)
+            // Now we need to create the curstats record.
+            // New accounts are not playable without this.
+            axios
+              .post('/api/createCurstatsRecord', {
+                playerId: response?.data,
+              })
+              .then(response => {
+                if (typeof response?.data === 'number') {
+                  redirectTo(`/account/game-accounts/create/success?accountName=${accountName}`)
+                }
+              })
           }
         })
         .catch((error: { response: { data: string } }) => {

--- a/src/pages/api/createCurstatsRecord/index.ts
+++ b/src/pages/api/createCurstatsRecord/index.ts
@@ -3,8 +3,8 @@ import { User } from '@globalTypes/User'
 import { handleManipulate } from '@helpers/apiHandler'
 
 const handler = async (req: NextApiRequest, res: NextApiResponse<User>) => {
-  const { accountId, currentName, newName } = req.body
-  const query = `UPDATE players SET former_name = '${currentName}', username = '${newName}' WHERE id = ${accountId}`
+  const { playerId } = req.body
+  const query = `INSERT INTO curstats VALUES (${playerId}, 1, 1, 1, 10, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1)`
 
   return handleManipulate('game', query, res)
 }

--- a/src/pages/api/createGameAccount/index.ts
+++ b/src/pages/api/createGameAccount/index.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 import { User } from '@globalTypes/User'
-import { handleUpdate } from '@helpers/apiHandler'
+import { handleManipulate } from '@helpers/apiHandler'
 
 const handler = async (req: NextApiRequest, res: NextApiResponse<User>) => {
   const { accountName, password, websiteAccountId, userIp } = req.body
@@ -9,7 +9,8 @@ const handler = async (req: NextApiRequest, res: NextApiResponse<User>) => {
   const query = `INSERT INTO players (username, pass, creation_date, creation_ip, websiteUserId)
     VALUES ('${accountName}', '${password}', ${creationDateMillis}, '${userIp}', '${websiteAccountId}')`
 
-  return handleUpdate('game', query, res)
+  // Create the player record and return the new record ID.
+  return handleManipulate('game', query, res, true)
 }
 
 export default handler

--- a/src/pages/api/updateGameAccountPassword/index.ts
+++ b/src/pages/api/updateGameAccountPassword/index.ts
@@ -1,12 +1,12 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 import { User } from '@globalTypes/User'
-import { handleUpdate } from '@helpers/apiHandler'
+import { handleManipulate } from '@helpers/apiHandler'
 
 const handler = async (req: NextApiRequest, res: NextApiResponse<User>) => {
   const { accountId, newPassword } = req.body
   const query = `UPDATE players SET pass = '${newPassword}' WHERE id = ${accountId}`
 
-  return handleUpdate('game', query, res)
+  return handleManipulate('game', query, res)
 }
 
 export default handler

--- a/src/pages/api/updateLastLogin/index.ts
+++ b/src/pages/api/updateLastLogin/index.ts
@@ -1,13 +1,13 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 import { User } from '@globalTypes/User'
-import { handleUpdate } from '@helpers/apiHandler'
+import { handleManipulate } from '@helpers/apiHandler'
 
 const handler = async (req: NextApiRequest, res: NextApiResponse<User>) => {
   const { userId } = req.body
   const now = new Date().toISOString()
   const query = `UPDATE users SET lastLogin = '${now}', dateModified = '${now}' WHERE id = '${userId}'`
 
-  return handleUpdate('website', query, res)
+  return handleManipulate('website', query, res)
 }
 
 export default handler

--- a/src/pages/api/updateWebsiteUserPassword/index.ts
+++ b/src/pages/api/updateWebsiteUserPassword/index.ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import { handleUpdate } from '@helpers/apiHandler'
+import { handleManipulate } from '@helpers/apiHandler'
 import { User } from '@globalTypes/User'
 
 const handler = async (req: NextApiRequest, res: NextApiResponse<User>) => {
@@ -7,7 +7,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse<User>) => {
   const now = new Date().toISOString()
   const query = `UPDATE users SET password = '${newPassword}', passwordSalt = '${newPasswordSalt}', dateModified = '${now}'  WHERE id = '${userId}'`
 
-  return handleUpdate('website', query, res)
+  return handleManipulate('website', query, res)
 }
 
 export default handler


### PR DESCRIPTION
- Fixed game account creation so that a `curstats` record is created after the player record is, therefore fixing an issue with new accounts created through the website not being able to complete the tutorial.
- Renamed `handleUpdate` to `handleManipulate`