### PR TITLE
F2P-60 | Handle page loads better so that "Access Denied" block doesn't show for a split second

### DIFF
--- a/src/components/molecules/AccountWidget/AccountWidget.styled.ts
+++ b/src/components/molecules/AccountWidget/AccountWidget.styled.ts
@@ -40,5 +40,6 @@ export const Username = styled(InlineLink, {
 export const AccountAreaLink = styled(HoverUnderlineLink)(
   () => css`
     color: unset;
+    font-size: 20px;
   `,
 )

--- a/src/components/molecules/AlreadyLoggedIn/AlreadyLoggedIn.tsx
+++ b/src/components/molecules/AlreadyLoggedIn/AlreadyLoggedIn.tsx
@@ -3,16 +3,26 @@ import { ContentBlock } from '@atoms/ContentBlock'
 import { BodyText } from '@atoms/BodyText'
 import { InlineLink } from '@atoms/InlineLink'
 
-const AlreadyLoggedIn = () => (
-  <ContentBlock>
-    <Typography variant='h2'>Login</Typography>
-    <BodyText textAlign='center'>
-      <Typography variant='body' component='span'>
-        You are already logged in. You can visit your
-        <InlineLink href='/account'>Account page</InlineLink>.
-      </Typography>
-    </BodyText>
-  </ContentBlock>
-)
+type AlreadyLoggedInProps = {
+  message?: JSX.Element | string
+}
+
+const AlreadyLoggedIn = (props: AlreadyLoggedInProps) => {
+  const { message } = props
+
+  return (
+    <ContentBlock>
+      <Typography variant='h2'>Already Logged In</Typography>
+      <BodyText variant='body' textAlign='center'>
+        {message || (
+          <>
+            You are already logged in. You can visit your
+            <InlineLink href='/account'>Account page</InlineLink>.
+          </>
+        )}
+      </BodyText>
+    </ContentBlock>
+  )
+}
 
 export default AlreadyLoggedIn

--- a/src/components/molecules/NotLoggedIn/NotLoggedIn.tsx
+++ b/src/components/molecules/NotLoggedIn/NotLoggedIn.tsx
@@ -7,8 +7,8 @@ const NotLoggedIn = () => (
   <ContentBlock>
     <Typography variant='h2'>Access Denied</Typography>
     <BodyText variant='body' textAlign='center'>
-      You are not logged in. This action is only available to users that are logged in. You can visit the{' '}
-      <InlineLink href='/account/login'>Login page</InlineLink>.
+      You are not currently logged in. Please visit the <InlineLink href='/account/login'>Login page</InlineLink> to log
+      in.
     </BodyText>
   </ContentBlock>
 )

--- a/src/hooks/useAuthentication.ts
+++ b/src/hooks/useAuthentication.ts
@@ -1,9 +1,14 @@
 import { User } from '@globalTypes/User'
 import { NullUser } from '@models/NullUser'
 import axios from 'axios'
-import { useEffect, useState } from 'react'
+import { Dispatch, SetStateAction, useEffect, useState } from 'react'
 
-const useAuthentication = () => {
+/** `setLoading` should be provided whenever this hook is used on a page that
+ * returns different JSX based on wehther the user is logged in, is an admin, or
+ * any other data associated with the user. This prevents the wrong text being
+ * shown on the screen for a brief moment.
+ */
+const useAuthentication = (setLoading?: Dispatch<SetStateAction<boolean>>) => {
   const [user, setUser] = useState<User>(NullUser)
 
   useEffect(() => {
@@ -12,12 +17,14 @@ const useAuthentication = () => {
         .get('/api/ironUser')
         .then(response => {
           setUser(response?.data)
+          setLoading?.(false)
         })
         .catch((error: string) => error)
     }
 
     fetchLoginStatus()
     return () => fetchLoginStatus()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   return user

--- a/src/hooks/useAuthentication.ts
+++ b/src/hooks/useAuthentication.ts
@@ -4,7 +4,7 @@ import axios from 'axios'
 import { Dispatch, SetStateAction, useEffect, useState } from 'react'
 
 /** `setLoading` should be provided whenever this hook is used on a page that
- * returns different JSX based on wehther the user is logged in, is an admin, or
+ * returns different JSX based on whether the user is logged in, is an admin, or
  * any other data associated with the user. This prevents the wrong text being
  * shown on the screen for a brief moment.
  */

--- a/src/pages/account/create/index.tsx
+++ b/src/pages/account/create/index.tsx
@@ -14,8 +14,11 @@ import useAuthentication from '@hooks/useAuthentication'
 import { redirectTo } from '@helpers/window'
 import { UserExists } from '@helpers/users/users'
 import { FormButton } from '@atoms/FormButton/FormButton'
+import { AlreadyLoggedIn } from '@molecules/AlreadyLoggedIn'
+import { Spinner } from '@molecules/Spinner'
 
 const CreateAccountPage = () => {
+  const [loading, setLoading] = useState(true)
   const [email, setEmail] = useState('')
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
@@ -23,7 +26,7 @@ const CreateAccountPage = () => {
   const [validationError, setValidationError] = useState('')
   const [existingUsernames, setExistingUsernames] = useState<string[]>([])
   const [existingEmailAddresses, setExistingEmailAddresses] = useState<string[]>([])
-  const user = useAuthentication()
+  const user = useAuthentication(setLoading)
 
   const handleEmailChange = (event: ChangeEvent<HTMLInputElement>) => {
     setEmail(event.target.value)
@@ -121,6 +124,10 @@ const CreateAccountPage = () => {
       .catch((error: string) => error)
   }
 
+  if (loading) {
+    return <Spinner />
+  }
+
   if (existingEmailAddresses?.length < 1 || existingUsernames?.length < 1) {
     fetchExistingUserInfo()
   }
@@ -128,12 +135,7 @@ const CreateAccountPage = () => {
   if (UserExists(user)) {
     // Logged-in users should not see this page
     return (
-      <ContentBlock>
-        <Typography variant='h2'>Already Logged In</Typography>
-        <BodyText variant='body' textAlign='center'>
-          You already have an account! If you wish to create a new one, please log out first.
-        </BodyText>
-      </ContentBlock>
+      <AlreadyLoggedIn message='You already have an account! If you wish to create a new one, please log out first.' />
     )
   }
 

--- a/src/pages/account/create/success/index.tsx
+++ b/src/pages/account/create/success/index.tsx
@@ -3,9 +3,16 @@ import { ContentBlock } from '@atoms/ContentBlock'
 import { BodyText } from '@atoms/BodyText'
 import { InlineLink } from '@atoms/InlineLink'
 import useAuthentication from '@hooks/useAuthentication'
+import { Spinner } from '@molecules/Spinner'
+import { useState } from 'react'
 
 const CreateAccountSuccessPage = () => {
-  const user = useAuthentication()
+  const [loading, setLoading] = useState(true)
+  const user = useAuthentication(setLoading)
+
+  if (loading) {
+    return <Spinner />
+  }
 
   if (user?.id === 'NULL') {
     // Something went wrong...

--- a/src/pages/account/game-accounts/create/index.tsx
+++ b/src/pages/account/game-accounts/create/index.tsx
@@ -13,14 +13,16 @@ import { hashPassword } from '@helpers/password'
 import useAuthentication from '@hooks/useAuthentication'
 import { UserIsLoggedIn } from '@helpers/users/users'
 import { NotLoggedIn } from '@molecules/NotLoggedIn'
+import { Spinner } from '@molecules/Spinner'
 
 const CreateGameAccount = () => {
-  const user = useAuthentication()
+  const [loading, setLoading] = useState(true)
   const [accountName, setAccountName] = useState('')
   const [password, setPassword] = useState('')
   const [confirmPassword, setConfirmPassword] = useState('')
   const [validationError, setValidationError] = useState('')
   const [currentAccountNames, setCurrentAccountNames] = useState('')
+  const user = useAuthentication(setLoading)
 
   const handleAccountNameChange = (event: ChangeEvent<HTMLInputElement>) => {
     setAccountName(event.target.value)
@@ -94,6 +96,10 @@ const CreateGameAccount = () => {
         setCurrentAccountNames(allAccountNames)
       })
       .catch((error: string) => error)
+  }
+
+  if (loading) {
+    return <Spinner />
   }
 
   if (!UserIsLoggedIn(user)) {

--- a/src/pages/account/game-accounts/create/success/index.tsx
+++ b/src/pages/account/game-accounts/create/success/index.tsx
@@ -6,11 +6,18 @@ import { useRouter } from 'next/router'
 import useAuthentication from '@hooks/useAuthentication'
 import { UserIsLoggedIn } from '@helpers/users/users'
 import { NotLoggedIn } from '@molecules/NotLoggedIn'
+import { useState } from 'react'
+import { Spinner } from '@molecules/Spinner'
 
 const CreateAccountSuccessPage = () => {
+  const [loading, setLoading] = useState(true)
   const { query } = useRouter()
-  const user = useAuthentication()
+  const user = useAuthentication(setLoading)
   const accountName = query['accountName']
+
+  if (loading) {
+    return <Spinner />
+  }
 
   if (!UserIsLoggedIn(user)) {
     return <NotLoggedIn />

--- a/src/pages/account/game-accounts/create/success/index.tsx
+++ b/src/pages/account/game-accounts/create/success/index.tsx
@@ -23,13 +23,13 @@ const CreateAccountSuccessPage = () => {
     return <NotLoggedIn />
   }
 
-  if (accountName?.length && accountName?.length < 1) {
+  if (!accountName || accountName?.length < 1) {
     // Something went wrong...
     return (
       <ContentBlock>
         <Typography variant='h2'>Oops...</Typography>
         <BodyText variant='body' textAlign='center'>
-          Something went wrong... your game account name is {accountName}. Please report this to the admin.
+          Something went wrong... your game account name is empty. Please report this to the admin.
         </BodyText>
       </ContentBlock>
     )

--- a/src/pages/account/game-accounts/index.tsx
+++ b/src/pages/account/game-accounts/index.tsx
@@ -8,10 +8,17 @@ import { FormButton } from '@atoms/FormButton/FormButton'
 import { GameAccountsTableMobile } from '@organisms/GameAccountsTableMobile'
 import { redirectTo } from '@helpers/window'
 import { NotLoggedIn } from '@molecules/NotLoggedIn'
+import { useState } from 'react'
+import { Spinner } from '@molecules/Spinner'
 
 const GameAccountsPage = () => {
-  const user = useAuthentication()
+  const [loading, setLoading] = useState(true)
+  const user = useAuthentication(setLoading)
   const isLoggedIn = UserIsLoggedIn(user)
+
+  if (loading) {
+    return <Spinner />
+  }
 
   if (!isLoggedIn) {
     return <NotLoggedIn />

--- a/src/pages/account/index.tsx
+++ b/src/pages/account/index.tsx
@@ -1,16 +1,18 @@
 import { useState } from 'react'
 import { BodyText } from '@atoms/BodyText'
 import { ContentBlock } from '@atoms/ContentBlock'
-import { InlineLink } from '@atoms/InlineLink'
 import { Typography } from '@mui/material'
 import useAuthentication from '@hooks/useAuthentication'
 import { AccountNavigationContainer, AccountNavigationButton, AccountNavigationItem } from '@styledPages/Account.styled'
 import Menu from '@mui/material/Menu'
 import { UserIsLoggedIn } from '@helpers/users/users'
+import { NotLoggedIn } from '@molecules/NotLoggedIn'
+import { Spinner } from '@molecules/Spinner'
 
 const AccountPage = () => {
-  const user = useAuthentication()
+  const [loading, setLoading] = useState(true)
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
+  const user = useAuthentication(setLoading)
   const open = Boolean(anchorEl)
   const isLoggedIn = UserIsLoggedIn(user)
 
@@ -22,16 +24,12 @@ const AccountPage = () => {
     setAnchorEl(null)
   }
 
+  if (loading) {
+    return <Spinner />
+  }
+
   if (!isLoggedIn) {
-    return (
-      <ContentBlock>
-        <Typography variant='h2'>Account</Typography>
-        <BodyText variant='body'>
-          You are not currently logged in. Please visit the <InlineLink href='/account/login'>Login page</InlineLink> to
-          log in.
-        </BodyText>
-      </ContentBlock>
-    )
+    return <NotLoggedIn />
   }
 
   return (

--- a/src/pages/account/login/forgot-password/index.tsx
+++ b/src/pages/account/login/forgot-password/index.tsx
@@ -13,11 +13,17 @@ import { UserExists, UserIsLoggedIn } from '@helpers/users/users'
 import { AlreadyLoggedIn } from '@molecules/AlreadyLoggedIn'
 import emailjs from '@emailjs/browser'
 import { FormButton } from '@atoms/FormButton/FormButton'
+import { Spinner } from '@molecules/Spinner'
 
 const ForgotPasswordPage = () => {
+  const [loading, setLoading] = useState(true)
   const [email, setEmail] = useState('')
-  const user = useAuthentication()
+  const user = useAuthentication(setLoading)
   const userIsLoggedIn = UserIsLoggedIn(user)
+
+  if (loading) {
+    return <Spinner />
+  }
 
   if (userIsLoggedIn) {
     return <AlreadyLoggedIn />

--- a/src/pages/account/login/index.tsx
+++ b/src/pages/account/login/index.tsx
@@ -17,12 +17,14 @@ import { HoverUnderlineLink } from '@atoms/HoverUnderlineLink'
 import { AlreadyLoggedIn } from '@molecules/AlreadyLoggedIn'
 import { UserExists, UserIsLoggedIn } from '@helpers/users/users'
 import { FormButton } from '@atoms/FormButton/FormButton'
+import { Spinner } from '@molecules/Spinner'
 
 const ForgotPasswordBlock = styled(BodyText)(
   () => css`
     flex-basis: 100%;
     font-family: Source Sans Pro;
     font-size: 16px;
+    text-align: left;
   `,
 )
 
@@ -33,11 +35,16 @@ const ForgotPasswordLink = styled(HoverUnderlineLink)(
 )
 
 const AccountLoginPage = () => {
+  const [loading, setLoading] = useState(true)
   const [usernameOrEmail, setUsernameOrEmail] = useState('')
   const [password, setPassword] = useState('')
   const [validationError, setValidationError] = useState('')
-  const user = useAuthentication()
+  const user = useAuthentication(setLoading)
   const userIsLoggedIn = UserIsLoggedIn(user)
+
+  if (loading) {
+    return <Spinner />
+  }
 
   if (userIsLoggedIn) {
     return <AlreadyLoggedIn />

--- a/src/pages/account/reset-password/success/index.tsx
+++ b/src/pages/account/reset-password/success/index.tsx
@@ -7,6 +7,7 @@ import { UserIsLoggedIn } from '@helpers/users/users'
 
 const ResetPasswordSuccessPage = () => {
   const user = useAuthentication()
+
   return (
     <ContentBlock>
       <Typography variant='h2'>Reset Successful</Typography>

--- a/src/pages/admin/newsPostForm/index.tsx
+++ b/src/pages/admin/newsPostForm/index.tsx
@@ -5,14 +5,16 @@ import { StyledForm, Field, SubmitArea, SubmitButton, SubmitMessage, FieldInfo }
 import Typography from '@mui/material/Typography'
 import { ContentBlock } from '@atoms/ContentBlock'
 import useAuthentication from '@hooks/useAuthentication'
+import { Spinner } from '@molecules/Spinner'
 
 const NewsPostForm = () => {
+  const [loading, setLoading] = useState(true)
   const [image, setImage] = useState<string>('')
   const [alt, setAlt] = useState<string>('')
   const [title, setTitle] = useState<string>('')
   const [body, setBody] = useState<string>('')
   const [submitResult, setSubmitResult] = useState<{ answer: string; code: string }>()
-  const user = useAuthentication()
+  const user = useAuthentication(setLoading)
 
   const handleImageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     if (event.target.files && event.target.files[0]) {
@@ -62,6 +64,10 @@ const NewsPostForm = () => {
           code: 'red',
         })
       })
+  }
+
+  if (loading) {
+    return <Spinner />
   }
 
   if (!user?.isAdmin) {


### PR DESCRIPTION
- Added loading spinner to all pages that call `useAuthentication` and return different JSX based on the user returned from this hook. This prevents pages from showing the wrong information for a split second because the user has not been fetched from the API yet.
- Refactored `AlreadyLoggedIn` to accept a custom message
- Updated the create page to use `AlreadyLoggedIn`
- Fixed an account widget link styling issue on mobile
- Tweaked the `NotLoggedIn` component message
- Made the Forgot Password block left-aligned
- Fixed problem with error state not appearing on `/account/game-accounts/create/success` page