### PR TITLE
F2P-68 | Passwords cannot have special characters, but should be able to (Temporary fix)

### DIFF
--- a/src/components/organisms/PasswordModal/PasswordModal.tsx
+++ b/src/components/organisms/PasswordModal/PasswordModal.tsx
@@ -4,6 +4,7 @@ import axios from 'axios'
 import { Field } from '@atoms/Field'
 import { Modal } from '@molecules/Modal'
 import { hashPassword } from '@helpers/password'
+import { gameAccountPasswordIsValid } from '@helpers/string/stringUtils'
 
 type PasswordModalProps = {
   account: PlayerDataRow
@@ -44,6 +45,12 @@ const PasswordModal = (props: PasswordModalProps) => {
     // Make sure passwords match
     if (newPassword !== confirmNewPassword) {
       setValidationError('Passwords must match.')
+      return
+    }
+
+    // Make sure password is valid
+    if (!gameAccountPasswordIsValid(newPassword)) {
+      setValidationError('Game account passwords can only have letters, numbers and underscores.')
       return
     }
 

--- a/src/helpers/string/stringUtils.ts
+++ b/src/helpers/string/stringUtils.ts
@@ -3,3 +3,15 @@ export const cleanInputString = (text: string) => {
 
   return text.replace(/'/g, "\\'")
 }
+
+/** Checks if game account password string is valid.
+ * For now, we only allow game account passwords with letters, numbers and underscores. */
+export const gameAccountPasswordIsValid = (password: string) => {
+  const validPasswordMatches = password.match(/^[a-zA-Z0-9_]+$/g)
+
+  if (!validPasswordMatches || !validPasswordMatches?.[0]) {
+    return false
+  }
+
+  return true
+}

--- a/src/pages/account/game-accounts/create/index.tsx
+++ b/src/pages/account/game-accounts/create/index.tsx
@@ -14,7 +14,7 @@ import useAuthentication from '@hooks/useAuthentication'
 import { UserIsLoggedIn } from '@helpers/users/users'
 import { NotLoggedIn } from '@molecules/NotLoggedIn'
 import { Spinner } from '@molecules/Spinner'
-import { gameAccountPasswordIsValid, passwordIsValid } from '@helpers/string/stringUtils'
+import { gameAccountPasswordIsValid } from '@helpers/string/stringUtils'
 
 const CreateGameAccount = () => {
   const [loading, setLoading] = useState(true)

--- a/src/pages/account/game-accounts/create/index.tsx
+++ b/src/pages/account/game-accounts/create/index.tsx
@@ -14,6 +14,7 @@ import useAuthentication from '@hooks/useAuthentication'
 import { UserIsLoggedIn } from '@helpers/users/users'
 import { NotLoggedIn } from '@molecules/NotLoggedIn'
 import { Spinner } from '@molecules/Spinner'
+import { gameAccountPasswordIsValid, passwordIsValid } from '@helpers/string/stringUtils'
 
 const CreateGameAccount = () => {
   const [loading, setLoading] = useState(true)
@@ -69,6 +70,11 @@ const CreateGameAccount = () => {
     // Confirm passwords match
     if (password != confirmPassword) {
       setValidationError('Passwords do not match.')
+      return
+    }
+
+    if (!gameAccountPasswordIsValid(password)) {
+      setValidationError('Game account passwords can only have letters, numbers and underscores.')
       return
     }
 


### PR DESCRIPTION
# What's Changed
- Added new validation for game account passwords so they cannot contain spaces or any special characters except underscores