### PR TITLE
Upload Page Fix, `MustBeAdminBlock`, Folder Templates Config

### DIFF
--- a/.fttemplates/Component/[FTName].styled.ts
+++ b/.fttemplates/Component/[FTName].styled.ts
@@ -1,0 +1,8 @@
+import { styled } from '@mui/material/styles'
+import { css } from '@mui/system'
+
+export const StyledComponent = styled('div')(
+  ({ theme }) => css`
+    display: flex;
+  `,
+)

--- a/.fttemplates/Component/[FTName].tsx
+++ b/.fttemplates/Component/[FTName].tsx
@@ -1,0 +1,9 @@
+import { [FTName]Props } from './[FTName].types';
+
+const [FTName] = (props: [FTName]Props) => {
+  const { prop1, prop2 } = props;
+  
+  return <div>[FTName]</div>;
+}
+
+export default [FTName];

--- a/.fttemplates/Component/[FTName].types.ts
+++ b/.fttemplates/Component/[FTName].types.ts
@@ -1,0 +1,4 @@
+export type [FTName]Props = {
+  prop1: string;
+  prop2: string;
+}

--- a/.fttemplates/Component/index.ts
+++ b/.fttemplates/Component/index.ts
@@ -1,0 +1,1 @@
+export { default as [FTName] } from './[FTName]'

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+.fttemplates/*

--- a/src/components/molecules/MustBeAdminBlock/MustBeAdminBlock.tsx
+++ b/src/components/molecules/MustBeAdminBlock/MustBeAdminBlock.tsx
@@ -1,0 +1,14 @@
+import { BodyText } from '@atoms/BodyText'
+import { ContentBlock } from '@atoms/ContentBlock'
+import { Typography } from '@mui/material'
+
+const MustBeAdminBlock = () => (
+  <ContentBlock>
+    <Typography variant='h2'>Nice Try</Typography>
+    <BodyText variant='body' textAlign='center'>
+      You must be an administrator to perform that action.
+    </BodyText>
+  </ContentBlock>
+)
+
+export default MustBeAdminBlock

--- a/src/components/molecules/MustBeAdminBlock/index.ts
+++ b/src/components/molecules/MustBeAdminBlock/index.ts
@@ -1,0 +1,1 @@
+export { default as MustBeAdminBlock } from './MustBeAdminBlock'

--- a/src/pages/admin/newsPostForm/index.tsx
+++ b/src/pages/admin/newsPostForm/index.tsx
@@ -3,9 +3,9 @@ import axios from 'axios'
 import { convertBlobToBase64String } from '@helpers/base64'
 import { StyledForm, Field, SubmitArea, SubmitButton, SubmitMessage, FieldInfo } from '@styledPages/NewsPostForm.styled'
 import Typography from '@mui/material/Typography'
-import { ContentBlock } from '@atoms/ContentBlock'
 import useAuthentication from '@hooks/useAuthentication'
 import { Spinner } from '@molecules/Spinner'
+import { MustBeAdminBlock } from '@molecules/MustBeAdminBlock'
 
 const NewsPostForm = () => {
   const [loading, setLoading] = useState(true)
@@ -71,11 +71,7 @@ const NewsPostForm = () => {
   }
 
   if (!user?.isAdmin) {
-    return (
-      <ContentBlock>
-        <Typography variant='body'>You must be an administrator to perform that action.</Typography>
-      </ContentBlock>
-    )
+    return <MustBeAdminBlock />
   }
 
   return (

--- a/src/pages/admin/upload/index.tsx
+++ b/src/pages/admin/upload/index.tsx
@@ -1,12 +1,17 @@
 import { useState } from 'react'
 import { convertBlobToBase64String, convertBase64StringToBlob } from '@helpers/base64'
+import useAuthentication from '@hooks/useAuthentication'
+import { Spinner } from '@molecules/Spinner'
+import { MustBeAdminBlock } from '@molecules/MustBeAdminBlock'
 
 // This is just a test page to see how uploading images from Next.js could work. [F2P-4]
 // Mostly taken from https://codesandbox.io/s/thyb0?file=/pages/index.js:738-1088 and various SO posts
 const UploadPage = () => {
+  const [loading, setLoading] = useState(true)
   const [, setImage] = useState<string | Blob>('')
   const [createObjectURL, setCreateObjectURL] = useState('')
   const [convertedBlobUrl, setConvertedBlobUrl] = useState('')
+  const user = useAuthentication(setLoading)
 
   const uploadToClient = (event: any) => {
     if (event.target.files && event.target.files[0]) {
@@ -35,6 +40,14 @@ const UploadPage = () => {
       console.log('URL.createObjectURL(i)', URL.createObjectURL(i))
       setCreateObjectURL(URL.createObjectURL(i))
     }
+  }
+
+  if (loading) {
+    return <Spinner />
+  }
+
+  if (!user?.isAdmin) {
+    return <MustBeAdminBlock />
   }
 
   return (


### PR DESCRIPTION
# What's Changed

- Fixed upload page by moving it to `admin/` and locking access down to admins. **Notes**:
  - This page does NOT upload images to the database, it only uploads them to the page
  - This page is still useful because it logs an image's base 64 string when you upload it, which is useful for creating new `image` table records
- Reused admin message by creating `MustBeAdminBlock` component
- Added `.fttemplates` config so creating new components is easier
- Added `.fttemplates` files to Prettier ignore as they are not supposed to be syntactically valid
