### PR TITLE
F2P-96 | Remove mention of alpha period from How to Play, Spacing Fixes, New Utility Components

### DIFF
--- a/src/components/atoms/Callout/Callout.styled.ts
+++ b/src/components/atoms/Callout/Callout.styled.ts
@@ -4,7 +4,7 @@ import { css } from '@mui/system'
 export const Box = styled('div')(
   () => css`
     font-family: Source Sans Pro;
-    background-color: rgba(32, 85, 218, 1);
+    background-color: var(--faded-blue-bg-color);
     border: 2px solid darkblue;
     color: white;
     text-align: center;

--- a/src/components/atoms/Callout/Callout.styled.ts
+++ b/src/components/atoms/Callout/Callout.styled.ts
@@ -1,0 +1,13 @@
+import { styled } from '@mui/material/styles'
+import { css } from '@mui/system'
+
+export const Box = styled('div')(
+  () => css`
+    font-family: Source Sans Pro;
+    background-color: rgba(32, 85, 218, 1);
+    border: 2px solid darkblue;
+    color: white;
+    text-align: center;
+    padding: 16px;
+  `,
+)

--- a/src/components/atoms/Callout/Callout.tsx
+++ b/src/components/atoms/Callout/Callout.tsx
@@ -1,0 +1,10 @@
+import { Box } from './Callout.styled'
+import { CalloutProps } from './Callout.types'
+
+const Callout = (props: CalloutProps) => {
+  const { children } = props
+
+  return <Box>{children}</Box>
+}
+
+export default Callout

--- a/src/components/atoms/Callout/Callout.types.ts
+++ b/src/components/atoms/Callout/Callout.types.ts
@@ -1,0 +1,3 @@
+export type CalloutProps = {
+  children: string | string[] | JSX.Element
+}

--- a/src/components/atoms/Callout/index.ts
+++ b/src/components/atoms/Callout/index.ts
@@ -1,0 +1,1 @@
+export { default as Callout } from './Callout'

--- a/src/components/atoms/ContentBlock/ContentBlock.ts
+++ b/src/components/atoms/ContentBlock/ContentBlock.ts
@@ -5,7 +5,7 @@ export const ContentBlock = styled('div', {
 })<{ isWide?: boolean; topMargin?: number }>(
   ({ isWide, topMargin }) => `
     max-width: ${isWide ? '1200px' : '800px'};
-    margin: ${typeof topMargin === 'number' ? topMargin : 40}px auto;
+    margin: ${typeof topMargin === 'number' ? topMargin : 0}px auto;
     text-align: center;
   `,
 )

--- a/src/components/atoms/DiscordLink/DiscordLink.tsx
+++ b/src/components/atoms/DiscordLink/DiscordLink.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link'
+
+type DiscordLinkProps = {
+  /** Optional prop if you wish to wrap the Discord link in something other than "Discord". */
+  children?: JSX.Element | string
+}
+
+const DiscordLink = (props: DiscordLinkProps) => {
+  const { children } = props
+
+  return (
+    <Link href='https://discord.gg/wd67zUxPXn' target='_blank'>
+      {children || 'Discord'}
+    </Link>
+  )
+}
+
+export default DiscordLink

--- a/src/components/atoms/DiscordLink/index.ts
+++ b/src/components/atoms/DiscordLink/index.ts
@@ -1,0 +1,1 @@
+export { default as DiscordLink } from './DiscordLink'

--- a/src/components/atoms/HiscoresMenuItem/HiscoresMenuItem.styled.ts
+++ b/src/components/atoms/HiscoresMenuItem/HiscoresMenuItem.styled.ts
@@ -44,7 +44,7 @@ export const MenuItemButton = styled(Button)(
     justify-content: flex-start;
 
     :hover {
-      color: #2055da;
+      color: var(--faded-blue-bg-color);
     }
 
     ${theme.breakpoints.up('mobile')} {

--- a/src/components/atoms/HiscoresTable/HiscoresTable.styled.ts
+++ b/src/components/atoms/HiscoresTable/HiscoresTable.styled.ts
@@ -23,8 +23,8 @@ export const HiscoreTable = styled(Table, {
 })(
   () => css`
     font-family: Verdana;
-    background-color: rgba(218, 165, 32, 0.8);
-    border: 2px solid rgb(160, 82, 45);
+    background-color: var(--gold-bg-color);
+    border: 2px solid var(--gold-border-color);
   `,
 )
 

--- a/src/components/atoms/NewsPostDetailItem/NewsPostDetailItem.styled.ts
+++ b/src/components/atoms/NewsPostDetailItem/NewsPostDetailItem.styled.ts
@@ -9,12 +9,6 @@ export const NewsPostDetailContainer = styled('div')(
   `,
 )
 
-export const PageHeading = styled(Typography)(
-  () => css`
-    text-align: center;
-  `,
-)
-
 export const NewsPostTitle = styled(Typography)(
   () => css`
     margin-top: 20px;
@@ -49,10 +43,11 @@ export const NewsPostDetailAuthor = styled(Typography)(
 
 export const NewsPostDetailBody = styled(Typography)<ExtendedTypographyProps>(
   ({ theme }) => css`
-    margin-top: 20px;
+    display: block;
+    margin: 20px 0 0;
 
     ${theme.breakpoints.up('tablet')} {
-      margin-top: 40px;
+      margin: 40px 0 0;
     }
   `,
 )

--- a/src/components/atoms/NewsPostDetailItem/NewsPostDetailItem.tsx
+++ b/src/components/atoms/NewsPostDetailItem/NewsPostDetailItem.tsx
@@ -4,20 +4,20 @@ import { NewsPostItemProps } from '@globalTypes/NewsPostItemProps'
 import { getNewsPostImageUrl } from '@helpers/imageUtils'
 import {
   NewsPostDetailContainer,
-  PageHeading,
   NewsPostTitle,
   NewsPostDetailImage,
   NewsPostDetailDate,
   NewsPostDetailAuthor,
   NewsPostDetailBody,
 } from './NewsPostDetailItem.styled'
+import { PageHeading } from '@atoms/PageHeading'
 
 const NewsPostDetailItem = (props: NewsPostItemProps) => {
   const { newsPost } = props
 
   return (
     <NewsPostDetailContainer>
-      <PageHeading variant='h2'>News Post</PageHeading>
+      <PageHeading>News Post</PageHeading>
       <NewsPostTitle variant='h3'>{newsPost.title}</NewsPostTitle>
       <NewsPostDetailImage src={getNewsPostImageUrl(newsPost.image)} alt={newsPost.alt} />
       <NewsPostDetailDate variant='body'>{getPrettyDateStringFromISOString(newsPost.datePosted)}</NewsPostDetailDate>

--- a/src/components/atoms/PageHeading/PageHeading.styled.ts
+++ b/src/components/atoms/PageHeading/PageHeading.styled.ts
@@ -1,0 +1,10 @@
+import { Typography } from '@mui/material'
+import { styled } from '@mui/material/styles'
+import { css } from '@mui/system'
+
+export const Heading = styled(Typography)(
+  () => css`
+    margin-bottom: 40px;
+    text-align: center;
+  `,
+)

--- a/src/components/atoms/PageHeading/PageHeading.tsx
+++ b/src/components/atoms/PageHeading/PageHeading.tsx
@@ -1,0 +1,10 @@
+import { PageHeadingProps } from './PageHeading.types'
+import { Heading } from './PageHeading.styled'
+
+const PageHeading = (props: PageHeadingProps) => {
+  const { children } = props
+
+  return <Heading variant='h2'>{children}</Heading>
+}
+
+export default PageHeading

--- a/src/components/atoms/PageHeading/PageHeading.types.ts
+++ b/src/components/atoms/PageHeading/PageHeading.types.ts
@@ -1,0 +1,4 @@
+export type PageHeadingProps = {
+  /** The text of the heading. */
+  children: string | string[]
+}

--- a/src/components/atoms/PageHeading/index.ts
+++ b/src/components/atoms/PageHeading/index.ts
@@ -1,0 +1,1 @@
+export { default as PageHeading } from './PageHeading'

--- a/src/components/molecules/AlreadyLoggedIn/AlreadyLoggedIn.tsx
+++ b/src/components/molecules/AlreadyLoggedIn/AlreadyLoggedIn.tsx
@@ -1,7 +1,7 @@
-import { Typography } from '@mui/material'
 import { ContentBlock } from '@atoms/ContentBlock'
 import { BodyText } from '@atoms/BodyText'
 import { InlineLink } from '@atoms/InlineLink'
+import { PageHeading } from '@atoms/PageHeading'
 
 type AlreadyLoggedInProps = {
   message?: JSX.Element | string
@@ -12,7 +12,7 @@ const AlreadyLoggedIn = (props: AlreadyLoggedInProps) => {
 
   return (
     <ContentBlock>
-      <Typography variant='h2'>Already Logged In</Typography>
+      <PageHeading>Already Logged In</PageHeading>
       <BodyText variant='body' textAlign='center'>
         {message || (
           <>

--- a/src/components/molecules/MustBeAdminBlock/MustBeAdminBlock.tsx
+++ b/src/components/molecules/MustBeAdminBlock/MustBeAdminBlock.tsx
@@ -1,10 +1,10 @@
 import { BodyText } from '@atoms/BodyText'
 import { ContentBlock } from '@atoms/ContentBlock'
-import { Typography } from '@mui/material'
+import { PageHeading } from '@atoms/PageHeading'
 
 const MustBeAdminBlock = () => (
   <ContentBlock>
-    <Typography variant='h2'>Nice Try</Typography>
+    <PageHeading>Nice Try</PageHeading>
     <BodyText variant='body' textAlign='center'>
       You must be an administrator to perform that action.
     </BodyText>

--- a/src/components/molecules/NotLoggedIn/NotLoggedIn.tsx
+++ b/src/components/molecules/NotLoggedIn/NotLoggedIn.tsx
@@ -1,11 +1,11 @@
 import { BodyText } from '@atoms/BodyText'
 import { ContentBlock } from '@atoms/ContentBlock'
 import { InlineLink } from '@atoms/InlineLink'
-import { Typography } from '@mui/material'
+import { PageHeading } from '@atoms/PageHeading'
 
 const NotLoggedIn = () => (
   <ContentBlock>
-    <Typography variant='h2'>Access Denied</Typography>
+    <PageHeading>Access Denied</PageHeading>
     <BodyText variant='body' textAlign='center'>
       You are not currently logged in. Please visit the <InlineLink href='/account/login'>Login page</InlineLink> to log
       in.

--- a/src/components/molecules/PlayerLookup/PlayerLookup.styled.ts
+++ b/src/components/molecules/PlayerLookup/PlayerLookup.styled.ts
@@ -7,8 +7,8 @@ import { css } from '@mui/system'
 export const PlayerLookupContainer = styled('div')(
   ({ theme }) => css`
     max-width: 200px;
-    background-color: rgba(218, 165, 32, 0.8);
-    border: 2px solid rgb(160, 82, 45);
+    background-color: var(--gold-bg-color);
+    border: 2px solid var(--gold-border-color);
     padding: 10px 16px;
 
     ${theme.breakpoints.between('tablet', 'desktop')} {

--- a/src/components/molecules/PlayerLookup/PlayerLookup.styled.ts
+++ b/src/components/molecules/PlayerLookup/PlayerLookup.styled.ts
@@ -46,7 +46,7 @@ export const PlayerNameField = styled(Field)(
 
 export const LookupSubmitButton = styled(FormButton)(
   ({ theme }) => css`
-    background-color: #2055da;
+    background-color: var(--faded-blue-bg-color);
     margin-top: 20px;
 
     :hover {

--- a/src/components/organisms/GameAccountsTableMobile/GameAccountsTableMobile.styled.ts
+++ b/src/components/organisms/GameAccountsTableMobile/GameAccountsTableMobile.styled.ts
@@ -7,8 +7,6 @@ export const AccountTableContainer = styled(TableContainer, {
   shouldForwardProp: prop => prop !== 'component',
 })<{ component: any }>(
   ({ theme }) => css`
-    margin-top: 40px;
-
     ${theme.breakpoints.up('tablet')} {
       display: none;
     }

--- a/src/components/organisms/NewsAndUpdates/NewsAndUpdates.tsx
+++ b/src/components/organisms/NewsAndUpdates/NewsAndUpdates.tsx
@@ -6,6 +6,7 @@ import { NewsPostList, ViewAllNewsLink } from './NewsAndUpdates.styled'
 import { NewsPost } from '@globalTypes/NewsPost'
 import { NewsPostListItem } from '@organisms/NewsPostListItem'
 import { Spinner } from '@molecules/Spinner'
+import { PageHeading } from '@atoms/PageHeading'
 
 interface NewsAndUpdatesProps {
   heading: string
@@ -44,7 +45,7 @@ const NewsAndUpdates = (props: NewsAndUpdatesProps) => {
 
   return (
     <ContentBlock isWide>
-      <Typography variant='h2'>{heading}</Typography>
+      <PageHeading>{heading}</PageHeading>
       <NewsPostList disablePadding>
         {newsPosts.map((newsPost: NewsPost) => (
           <NewsPostListItem key={newsPost.id} newsPost={newsPost} />

--- a/src/components/organisms/OnlinePlayers/OnlinePlayers.styled.ts
+++ b/src/components/organisms/OnlinePlayers/OnlinePlayers.styled.ts
@@ -8,7 +8,7 @@ export const PlayersOnlineBox = styled('div')`
 
 export const PlayersOnlineMessage = styled('p')(
   ({ theme }) => css`
-    font-family: Helvetica;
+    font-family: Verdana;
     font-size: 20px;
     text-align: center;
     margin: 20px 0;

--- a/src/pages/about/index.tsx
+++ b/src/pages/about/index.tsx
@@ -1,20 +1,21 @@
-import { Typography } from '@mui/material'
-import { Feature, FeatureList, Paragraph } from '@styledPages/About.styled'
+import { Feature, FeatureList } from '@styledPages/About.styled'
 import { ContentBlock } from '@atoms/ContentBlock'
+import { PageHeading } from '@atoms/PageHeading'
+import { BodyText } from '@atoms/BodyText'
 
 const About = () => (
   <ContentBlock>
-    <Typography variant='h2'>Our Spin on RSC</Typography>
-    <Paragraph variant='body'>
+    <PageHeading>Our Spin on RSC</PageHeading>
+    <BodyText variant='body' textAlign='center'>
       Neat F2P is an <strong>unreleased</strong> F2P-only, 1x EXP, mostly-authentic RuneScape Classic private server
       that runs on the Open RSC framework. This is F2P in RuneScape as it was in 2002-2003, just without members
       content. Of course, it is actually free to play - no credit card required.
-    </Paragraph>
-    <Paragraph variant='body'>
+    </BodyText>
+    <BodyText variant='body' textAlign='center'>
       We seek to provide the RSC F2P nostalgia, but with an added twist: <em>there are no members items or worlds.</em>{' '}
       You&apos;ll find that some items which are considered F2P, but were only accessible in members lands, will be
       unobtainable. In this way, Neat F2P provides a unique RSC experience that we have never seen!
-    </Paragraph>
+    </BodyText>
     <FeatureList>
       <Feature>Based on Open RSC&apos;s Core Framework with Few or No Added Changes</Feature>
       <Feature>Open Source (Game & Website) Forever</Feature>

--- a/src/pages/about/index.tsx
+++ b/src/pages/about/index.tsx
@@ -1,7 +1,6 @@
 import { Typography } from '@mui/material'
-import { Paragraph } from '@styledPages/About.styled'
+import { Feature, FeatureList, Paragraph } from '@styledPages/About.styled'
 import { ContentBlock } from '@atoms/ContentBlock'
-import Link from 'next/link'
 
 const About = () => (
   <ContentBlock>
@@ -16,9 +15,21 @@ const About = () => (
       You&apos;ll find that some items which are considered F2P, but were only accessible in members lands, will be
       unobtainable. In this way, Neat F2P provides a unique RSC experience that we have never seen!
     </Paragraph>
-    <Paragraph variant='body'>
-      So, <Link href='/how-to-play'>jump in today</Link> and experience what a F2P-only economy can be!
-    </Paragraph>
+    <FeatureList>
+      <Feature>Based on Open RSC&apos;s Core Framework with Few or No Added Changes</Feature>
+      <Feature>Open Source (Game & Website) Forever</Feature>
+      <Feature>F2P Mode Enabled (Forever) - Only F2P Areas, Features, Items, Quests, Spells, Prayers, Etc.</Feature>
+      <Feature>1x EXP Rates</Feature>
+      <Feature>1 Page Bank (Authentic F2P Behavior)</Feature>
+      <Feature>Play with RSC+ Client and WinRune (Web Client In Discovery)</Feature>
+      <Feature>Skip Tutorial Option Enabled</Feature>
+      <Feature>Max 2 Characters Logged In At Once</Feature>
+      <Feature>No QOL - Straight RSC</Feature>
+      <Feature>No Global Chat or Kill Feed</Feature>
+      <Feature>No Transfers From Other Servers</Feature>
+      <Feature>No Cheating</Feature>
+      <Feature>Aiming for a Spring 2024 Release</Feature>
+    </FeatureList>
   </ContentBlock>
 )
 

--- a/src/pages/account/create/index.tsx
+++ b/src/pages/account/create/index.tsx
@@ -1,5 +1,4 @@
 import { FormEvent, ChangeEvent, useState } from 'react'
-import { Typography } from '@mui/material'
 import { ContentBlock } from '@atoms/ContentBlock'
 import { Form } from '@atoms/Form'
 import { BodyText } from '@atoms/BodyText'
@@ -16,6 +15,7 @@ import { UserExists } from '@helpers/users/users'
 import { FormButton } from '@atoms/FormButton/FormButton'
 import { AlreadyLoggedIn } from '@molecules/AlreadyLoggedIn'
 import { Spinner } from '@molecules/Spinner'
+import { PageHeading } from '@atoms/PageHeading'
 
 const CreateAccountPage = () => {
   const [loading, setLoading] = useState(true)
@@ -141,7 +141,7 @@ const CreateAccountPage = () => {
 
   return (
     <ContentBlock>
-      <Typography variant='h2'>Create Account</Typography>
+      <PageHeading>Create Account</PageHeading>
       <BodyText variant='body' textAlign='left'>
         By creating a website account, you can add or rename game accounts, update passwords, and some other nifty
         things.

--- a/src/pages/account/create/success/index.tsx
+++ b/src/pages/account/create/success/index.tsx
@@ -1,10 +1,10 @@
-import { Typography } from '@mui/material'
 import { ContentBlock } from '@atoms/ContentBlock'
 import { BodyText } from '@atoms/BodyText'
 import { InlineLink } from '@atoms/InlineLink'
 import useAuthentication from '@hooks/useAuthentication'
 import { Spinner } from '@molecules/Spinner'
 import { useState } from 'react'
+import { PageHeading } from '@atoms/PageHeading'
 
 const CreateAccountSuccessPage = () => {
   const [loading, setLoading] = useState(true)
@@ -18,7 +18,7 @@ const CreateAccountSuccessPage = () => {
     // Something went wrong...
     return (
       <ContentBlock>
-        <Typography variant='h2'>Oops...</Typography>
+        <PageHeading>Oops...</PageHeading>
         <BodyText variant='body' textAlign='center'>
           Something went wrong... you are now {user?.username}! Tell all your friends, then try logging in again, or
           notify the admin
@@ -29,7 +29,7 @@ const CreateAccountSuccessPage = () => {
 
   return (
     <ContentBlock>
-      <Typography variant='h2'>Success</Typography>
+      <PageHeading>Success</PageHeading>
       <BodyText variant='body' textAlign='center'>
         Your account, {user?.username}, has been created! You can now view your
         <InlineLink href='/account'>Account page</InlineLink>.

--- a/src/pages/account/game-accounts/create/index.tsx
+++ b/src/pages/account/game-accounts/create/index.tsx
@@ -6,7 +6,6 @@ import { Form } from '@atoms/Form'
 import { FormButton } from '@atoms/FormButton/FormButton'
 import { PlayerDataRow } from '@globalTypes/Database/PlayerDataRow'
 import { redirectTo } from '@helpers/window'
-import { Typography } from '@mui/material'
 import axios from 'axios'
 import { ChangeEvent, FormEvent, useState } from 'react'
 import { hashPassword } from '@helpers/password'
@@ -15,6 +14,7 @@ import { UserIsLoggedIn } from '@helpers/users/users'
 import { NotLoggedIn } from '@molecules/NotLoggedIn'
 import { Spinner } from '@molecules/Spinner'
 import { gameAccountPasswordIsValid } from '@helpers/string/stringUtils'
+import { PageHeading } from '@atoms/PageHeading'
 
 const CreateGameAccount = () => {
   const [loading, setLoading] = useState(true)
@@ -183,7 +183,7 @@ const CreateGameAccount = () => {
 
   return (
     <ContentBlock>
-      <Typography variant='h2'>Create Game Account</Typography>
+      <PageHeading>Create Game Account</PageHeading>
       <BodyText variant='body' textAlign='left'>
         Game account names must be 12 characters or less. You are allowed spaces within your name, but any spaces at the
         start or end of your name will be removed upon account creation.

--- a/src/pages/account/game-accounts/create/success/index.tsx
+++ b/src/pages/account/game-accounts/create/success/index.tsx
@@ -1,4 +1,3 @@
-import { Typography } from '@mui/material'
 import { ContentBlock } from '@atoms/ContentBlock'
 import { BodyText } from '@atoms/BodyText'
 import { InlineLink } from '@atoms/InlineLink'
@@ -8,6 +7,7 @@ import { UserIsLoggedIn } from '@helpers/users/users'
 import { NotLoggedIn } from '@molecules/NotLoggedIn'
 import { useState } from 'react'
 import { Spinner } from '@molecules/Spinner'
+import { PageHeading } from '@atoms/PageHeading'
 
 const CreateAccountSuccessPage = () => {
   const [loading, setLoading] = useState(true)
@@ -27,7 +27,7 @@ const CreateAccountSuccessPage = () => {
     // Something went wrong...
     return (
       <ContentBlock>
-        <Typography variant='h2'>Oops...</Typography>
+        <PageHeading>Oops...</PageHeading>
         <BodyText variant='body' textAlign='center'>
           Something went wrong... your game account name is empty. Please report this to the admin.
         </BodyText>
@@ -37,7 +37,7 @@ const CreateAccountSuccessPage = () => {
 
   return (
     <ContentBlock>
-      <Typography variant='h2'>Success</Typography>
+      <PageHeading>Success</PageHeading>
       <BodyText variant='body' textAlign='center'>
         Your game account, <strong>{accountName}</strong>, has been created. You can now log in.
       </BodyText>

--- a/src/pages/account/game-accounts/index.tsx
+++ b/src/pages/account/game-accounts/index.tsx
@@ -1,6 +1,5 @@
 import { BodyText } from '@atoms/BodyText'
 import { ContentBlock } from '@atoms/ContentBlock'
-import { Typography } from '@mui/material'
 import useAuthentication from '@hooks/useAuthentication'
 import { GameAccountsTable } from '@organisms/GameAccountsTable'
 import { UserIsLoggedIn } from '@helpers/users/users'
@@ -11,6 +10,7 @@ import { NotLoggedIn } from '@molecules/NotLoggedIn'
 import { useState } from 'react'
 import { Spinner } from '@molecules/Spinner'
 import { PlayerDataRow } from '@globalTypes/Database/PlayerDataRow'
+import { PageHeading } from '@atoms/PageHeading'
 
 const GameAccountsPage = () => {
   const [loading, setLoading] = useState(true)
@@ -44,8 +44,8 @@ const GameAccountsPage = () => {
 
   return (
     <ContentBlock isWide>
-      <Typography variant='h2'>Game Accounts</Typography>
-      <BodyText variant='body'>
+      <PageHeading>Game Accounts</PageHeading>
+      <BodyText variant='body' textAlign='center'>
         Here, you can view your current game accounts, create new ones, rename them, and update passwords. All times
         shown are in your local timezone.
       </BodyText>

--- a/src/pages/account/index.tsx
+++ b/src/pages/account/index.tsx
@@ -1,13 +1,13 @@
 import { useState } from 'react'
 import { BodyText } from '@atoms/BodyText'
 import { ContentBlock } from '@atoms/ContentBlock'
-import { Typography } from '@mui/material'
 import useAuthentication from '@hooks/useAuthentication'
 import { AccountNavigationContainer, AccountNavigationButton, AccountNavigationItem } from '@styledPages/Account.styled'
 import Menu from '@mui/material/Menu'
 import { UserIsLoggedIn } from '@helpers/users/users'
 import { NotLoggedIn } from '@molecules/NotLoggedIn'
 import { Spinner } from '@molecules/Spinner'
+import { PageHeading } from '@atoms/PageHeading'
 
 const AccountPage = () => {
   const [loading, setLoading] = useState(true)
@@ -34,8 +34,8 @@ const AccountPage = () => {
 
   return (
     <ContentBlock>
-      <Typography variant='h2'>Hiya, {user?.username}!</Typography>
-      <BodyText variant='body'>
+      <PageHeading>Hiya, {user?.username}!</PageHeading>
+      <BodyText variant='body' textAlign='center'>
         Welcome to your account page. Here, you can modify your website account, create game (RSC) accounts, rename game
         accounts and update passwords. (You can&apos;t update your website account right now, but that will be
         implemented soon!)

--- a/src/pages/account/login/forgot-password/index.tsx
+++ b/src/pages/account/login/forgot-password/index.tsx
@@ -1,5 +1,4 @@
 import { FormEvent, useState, ChangeEvent } from 'react'
-import { Typography } from '@mui/material'
 import { ContentBlock } from '@atoms/ContentBlock'
 import { Form } from '@atoms/Form'
 import { BodyText } from '@atoms/BodyText'
@@ -8,13 +7,13 @@ import { InlineLink } from '@atoms/InlineLink'
 import axios from 'axios'
 import useAuthentication from '@hooks/useAuthentication'
 import { redirectTo } from '@helpers/window'
-import Link from 'next/link'
 import { UserExists, UserIsLoggedIn } from '@helpers/users/users'
 import { AlreadyLoggedIn } from '@molecules/AlreadyLoggedIn'
 import emailjs from '@emailjs/browser'
 import { FormButton } from '@atoms/FormButton/FormButton'
 import { Spinner } from '@molecules/Spinner'
 import { DiscordLink } from '@atoms/DiscordLink'
+import { PageHeading } from '@atoms/PageHeading'
 
 const ForgotPasswordPage = () => {
   const [loading, setLoading] = useState(true)
@@ -60,7 +59,7 @@ const ForgotPasswordPage = () => {
 
   return (
     <ContentBlock>
-      <Typography variant='h2'>Forgot Password</Typography>
+      <PageHeading>Forgot Password</PageHeading>
       <BodyText variant='body' textAlign='left'>
         Forgotten your password? Enter your email below and we will send you a password reset link. If you have
         forgotten your username and email as well, please contact an administrator in{' '}

--- a/src/pages/account/login/forgot-password/index.tsx
+++ b/src/pages/account/login/forgot-password/index.tsx
@@ -14,6 +14,7 @@ import { AlreadyLoggedIn } from '@molecules/AlreadyLoggedIn'
 import emailjs from '@emailjs/browser'
 import { FormButton } from '@atoms/FormButton/FormButton'
 import { Spinner } from '@molecules/Spinner'
+import { DiscordLink } from '@atoms/DiscordLink'
 
 const ForgotPasswordPage = () => {
   const [loading, setLoading] = useState(true)
@@ -63,9 +64,7 @@ const ForgotPasswordPage = () => {
       <BodyText variant='body' textAlign='left'>
         Forgotten your password? Enter your email below and we will send you a password reset link. If you have
         forgotten your username and email as well, please contact an administrator in{' '}
-        <Link href='https://discord.gg/wd67zUxPXn' target='_blank'>
-          Neat F2P&apos;s Discord server
-        </Link>
+        <DiscordLink>Neat F2P&apos;s Discord server</DiscordLink>
         {''}.
       </BodyText>
       <Form onSubmit={handleRequest}>

--- a/src/pages/account/login/forgot-password/success/index.tsx
+++ b/src/pages/account/login/forgot-password/success/index.tsx
@@ -1,12 +1,12 @@
-import { Typography } from '@mui/material'
 import { ContentBlock } from '@atoms/ContentBlock'
 import { BodyText } from '@atoms/BodyText'
 import { InlineLink } from '@atoms/InlineLink'
+import { PageHeading } from '@atoms/PageHeading'
 
 const ForgotPasswordSuccessPage = () => {
   return (
     <ContentBlock>
-      <Typography variant='h2'>Request Received</Typography>
+      <PageHeading>Request Received</PageHeading>
       <BodyText variant='body' textAlign='center'>
         If the email you entered is associated with an account, you will receive an email with a password reset link
         within the next 5-10 minutes. You can now return to the

--- a/src/pages/account/login/index.tsx
+++ b/src/pages/account/login/index.tsx
@@ -1,5 +1,4 @@
 import { FormEvent, useState, ChangeEvent } from 'react'
-import { Typography } from '@mui/material'
 import { styled } from '@mui/material/styles'
 import { css } from '@mui/system'
 import { ContentBlock } from '@atoms/ContentBlock'
@@ -18,6 +17,7 @@ import { AlreadyLoggedIn } from '@molecules/AlreadyLoggedIn'
 import { UserExists, UserIsLoggedIn } from '@helpers/users/users'
 import { FormButton } from '@atoms/FormButton/FormButton'
 import { Spinner } from '@molecules/Spinner'
+import { PageHeading } from '@atoms/PageHeading'
 
 const ForgotPasswordBlock = styled(BodyText)(
   () => css`
@@ -121,7 +121,7 @@ const AccountLoginPage = () => {
 
   return (
     <ContentBlock>
-      <Typography variant='h2'>Login</Typography>
+      <PageHeading>Login</PageHeading>
       <BodyText variant='body' textAlign='left'>
         Log in to your website account below.
       </BodyText>

--- a/src/pages/account/reset-password/[id].tsx
+++ b/src/pages/account/reset-password/[id].tsx
@@ -1,5 +1,4 @@
 import { useRouter } from 'next/router'
-import { Typography } from '@mui/material'
 import { ContentBlock } from '@atoms/ContentBlock'
 import { Form } from '@atoms/Form'
 import { Field } from '@atoms/Field'
@@ -9,6 +8,7 @@ import { FieldValidationError } from '@atoms/FieldValidationError'
 import { redirectTo } from '@helpers/window'
 import { FormButton } from '@atoms/FormButton/FormButton'
 import { hashPassword } from '@helpers/password'
+import { PageHeading } from '@atoms/PageHeading'
 
 const ResetPassword = () => {
   const { query } = useRouter()
@@ -60,7 +60,7 @@ const ResetPassword = () => {
 
   return (
     <ContentBlock>
-      <Typography variant='h2'>Reset Your Password</Typography>
+      <PageHeading>Reset Your Password</PageHeading>
       <Form onSubmit={handleRequest}>
         <Field
           required

--- a/src/pages/account/reset-password/success/index.tsx
+++ b/src/pages/account/reset-password/success/index.tsx
@@ -1,16 +1,16 @@
-import { Typography } from '@mui/material'
 import { ContentBlock } from '@atoms/ContentBlock'
 import { BodyText } from '@atoms/BodyText'
 import { InlineLink } from '@atoms/InlineLink'
 import useAuthentication from '@hooks/useAuthentication'
 import { UserIsLoggedIn } from '@helpers/users/users'
+import { PageHeading } from '@atoms/PageHeading'
 
 const ResetPasswordSuccessPage = () => {
   const user = useAuthentication()
 
   return (
     <ContentBlock>
-      <Typography variant='h2'>Reset Successful</Typography>
+      <PageHeading>Reset Successful</PageHeading>
       <BodyText variant='body' textAlign='center'>
         Your password was reset successfully.{' '}
         {!UserIsLoggedIn(user) && (

--- a/src/pages/admin/newsPostForm/index.tsx
+++ b/src/pages/admin/newsPostForm/index.tsx
@@ -2,10 +2,10 @@ import { useState } from 'react'
 import axios from 'axios'
 import { convertBlobToBase64String } from '@helpers/base64'
 import { StyledForm, Field, SubmitArea, SubmitButton, SubmitMessage, FieldInfo } from '@styledPages/NewsPostForm.styled'
-import Typography from '@mui/material/Typography'
 import useAuthentication from '@hooks/useAuthentication'
 import { Spinner } from '@molecules/Spinner'
 import { MustBeAdminBlock } from '@molecules/MustBeAdminBlock'
+import { PageHeading } from '@atoms/PageHeading'
 
 const NewsPostForm = () => {
   const [loading, setLoading] = useState(true)
@@ -76,7 +76,7 @@ const NewsPostForm = () => {
 
   return (
     <>
-      <Typography variant='h2'>Submit a News Post</Typography>
+      <PageHeading>Submit a News Post</PageHeading>
       <StyledForm onSubmit={handleSubmit}>
         <Field>
           <label htmlFor='imageSrc'>Image</label>

--- a/src/pages/bug-reports/index.tsx
+++ b/src/pages/bug-reports/index.tsx
@@ -1,22 +1,20 @@
+import { BodyText } from '@atoms/BodyText'
 import { ContentBlock } from '@atoms/ContentBlock'
+import { DiscordLink } from '@atoms/DiscordLink'
 import { Typography } from '@mui/material'
 import Link from 'next/link'
 
 const BugReports = () => (
-  <>
-    <ContentBlock topMargin={20}>
-      <Typography variant='body'>Coming Soon...</Typography>
-    </ContentBlock>
-    <ContentBlock topMargin={0}>
-      <Typography variant='body'>
-        For now, you can submit bugs via{' '}
-        <Link href='https://github.com/aldrichdev/Neat-F2P/issues' target='_blank'>
-          GitHub
-        </Link>
-        .
-      </Typography>
-    </ContentBlock>
-  </>
+  <ContentBlock topMargin={20}>
+    <Typography variant='h2'>Coming Soon</Typography>
+    <BodyText variant='body'>
+      For now, you can submit bugs via{' '}
+      <Link href='https://github.com/aldrichdev/Neat-F2P/issues' target='_blank'>
+        GitHub
+      </Link>{' '}
+      or in the #bug-reports channel of our <DiscordLink />.
+    </BodyText>
+  </ContentBlock>
 )
 
 export default BugReports

--- a/src/pages/bug-reports/index.tsx
+++ b/src/pages/bug-reports/index.tsx
@@ -1,12 +1,12 @@
 import { BodyText } from '@atoms/BodyText'
 import { ContentBlock } from '@atoms/ContentBlock'
 import { DiscordLink } from '@atoms/DiscordLink'
-import { Typography } from '@mui/material'
+import { PageHeading } from '@atoms/PageHeading'
 import Link from 'next/link'
 
 const BugReports = () => (
-  <ContentBlock topMargin={20}>
-    <Typography variant='h2'>Coming Soon</Typography>
+  <ContentBlock>
+    <PageHeading>Coming Soon</PageHeading>
     <BodyText variant='body'>
       For now, you can submit bugs via{' '}
       <Link href='https://github.com/aldrichdev/Neat-F2P/issues' target='_blank'>

--- a/src/pages/hiscores/index.tsx
+++ b/src/pages/hiscores/index.tsx
@@ -1,7 +1,5 @@
 import { ContentBlock } from '@atoms/ContentBlock'
-import { Typography } from '@mui/material'
 import { useEffect, useState } from 'react'
-import { BodyText } from '@atoms/BodyText'
 import { HiscoresPageContainer } from '@styledPages/hiscores.styled'
 import { HiscoresTable } from '@atoms/HiscoresTable'
 import { HiscoresMenu } from '@atoms/HiscoresMenu'
@@ -10,6 +8,8 @@ import { HiscoreTypes, HiscoreType } from '@globalTypes/Hiscores/HiscoreType'
 import { useRouter } from 'next/router'
 import { Spinner } from '@molecules/Spinner'
 import { PlayerLookup } from '@molecules/PlayerLookup'
+import { PageHeading } from '@atoms/PageHeading'
+import { Callout } from '@atoms/Callout'
 
 const Hiscores = () => {
   const [isLoading, setIsLoading] = useState(true)
@@ -24,11 +24,14 @@ const Hiscores = () => {
   }, [query])
 
   return (
-    <ContentBlock topMargin={20} isWide>
-      <Typography variant='h2'>{hiscoreType} Hiscores</Typography>
-      <BodyText variant='body' textAlign='center'>
-        Below are the current <strong>alpha</strong> {hiscoreType} hiscores.
-      </BodyText>
+    <ContentBlock isWide>
+      <PageHeading>{`${hiscoreType} Hiscores`}</PageHeading>
+      <Callout>
+        <span>
+          Hiscores currently show <strong>alpha tester</strong> accounts. These are temporary and will not be accessible
+          in the full game.
+        </span>
+      </Callout>
       <HiscoresPageContainer>
         <HiscoresMenu hiscoreType={hiscoreType} buttonOnClick={setHiscoreType} />
         {isLoading || !hiscores ? (

--- a/src/pages/hiscores/player/[accountName].tsx
+++ b/src/pages/hiscores/player/[accountName].tsx
@@ -1,5 +1,7 @@
 import { BodyText } from '@atoms/BodyText'
+import { Callout } from '@atoms/Callout'
 import { ContentBlock } from '@atoms/ContentBlock'
+import { PageHeading } from '@atoms/PageHeading'
 import { PlayerHiscoreTable } from '@atoms/PlayerHiscoreTable'
 import { HiscoreDataRow } from '@globalTypes/Database/HiscoreDataRow'
 import { HiscoresSortField } from '@globalTypes/Database/HiscoresSortField'
@@ -7,7 +9,6 @@ import { HiscoreType } from '@globalTypes/Hiscores/HiscoreType'
 import { PlayerHiscoreRow } from '@globalTypes/Hiscores/PlayerHiscoreRow'
 import { convertExp, getTotalExp } from '@helpers/hiscores/hiscoresUtils'
 import { Spinner } from '@molecules/Spinner'
-import { Typography } from '@mui/material'
 import { BackToHiscoresLink, PlayerHiscoreTableContainer } from '@styledPages/hiscores.styled'
 import axios from 'axios'
 import { useRouter } from 'next/router'
@@ -110,8 +111,8 @@ const PlayerHiscore = () => {
   }
 
   return (
-    <ContentBlock topMargin={20}>
-      <Typography variant='h2'>{accountName}</Typography>
+    <ContentBlock>
+      <PageHeading>{accountName ? accountName.toString() : 'Unknown Player'}</PageHeading>
       {typeof accountName !== 'string' ||
       !playerHiscores ||
       !hiscoresData?.find(hiscoreDataRow => hiscoreDataRow.username === accountName) ? (
@@ -119,9 +120,17 @@ const PlayerHiscore = () => {
           No hiscore found for this player.
         </BodyText>
       ) : (
-        <PlayerHiscoreTableContainer>
-          <PlayerHiscoreTable accountName={accountName} playerHiscores={playerHiscores} />
-        </PlayerHiscoreTableContainer>
+        <>
+          <Callout>
+            <span>
+              This is an <strong>alpha tester</strong> account. These are temporary and will not be accessible in the
+              full game.
+            </span>
+          </Callout>
+          <PlayerHiscoreTableContainer>
+            <PlayerHiscoreTable accountName={accountName} playerHiscores={playerHiscores} />
+          </PlayerHiscoreTableContainer>
+        </>
       )}
       <BackToHiscoresLink href='/hiscores'>{'<'} Return to Hiscores</BackToHiscoresLink>
     </ContentBlock>

--- a/src/pages/how-to-play/index.tsx
+++ b/src/pages/how-to-play/index.tsx
@@ -1,17 +1,15 @@
 import { Typography } from '@mui/material'
-import Link from 'next/link'
 import { ContentBlock } from '@atoms/ContentBlock'
+import { BodyText } from '@atoms/BodyText'
+import { DiscordLink } from '@atoms/DiscordLink'
 
 const HowToPlay = () => (
   <ContentBlock topMargin={20}>
-    <Typography variant='body'>
-      Neat F2P has not yet officially launched. However, we are currently in an alpha testing phase (until January
-      28th). If you would like to try out the alpha, please join our{' '}
-      <Link href='https://discord.gg/wd67zUxPXn' target='_blank'>
-        Discord
-      </Link>{' '}
-      and check the <strong>#alpha-testing-info</strong> channel for connection info!
-    </Typography>
+    <Typography variant='h2'>Coming Soon</Typography>
+    <BodyText variant='body'>
+      Neat F2P has not yet launched. Please keep checking our <DiscordLink /> for more info on when it will be ready to
+      play.
+    </BodyText>
   </ContentBlock>
 )
 

--- a/src/pages/how-to-play/index.tsx
+++ b/src/pages/how-to-play/index.tsx
@@ -1,12 +1,12 @@
-import { Typography } from '@mui/material'
 import { ContentBlock } from '@atoms/ContentBlock'
 import { BodyText } from '@atoms/BodyText'
 import { DiscordLink } from '@atoms/DiscordLink'
+import { PageHeading } from '@atoms/PageHeading'
 
 const HowToPlay = () => (
-  <ContentBlock topMargin={20}>
-    <Typography variant='h2'>Coming Soon</Typography>
-    <BodyText variant='body'>
+  <ContentBlock>
+    <PageHeading>Coming Soon</PageHeading>
+    <BodyText variant='body' textAlign='center'>
       Neat F2P has not yet launched. Please keep checking our <DiscordLink /> for more info on when it will be ready to
       play.
     </BodyText>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,6 +5,7 @@ import { OnlinePlayers } from '@organisms/OnlinePlayers'
 import { NewsAndUpdates } from '@organisms/NewsAndUpdates'
 import Link from 'next/link'
 import DiscordLogo from 'public/img/discord-512.webp'
+import { DiscordLink } from '@atoms/DiscordLink'
 
 const Homepage = () => (
   <div>
@@ -21,9 +22,9 @@ const Homepage = () => (
     <ContentBlock isWide>
       <Typography variant='h2'>Join the Community</Typography>
       <SectionBody variant='body'>Click the button below to join our Discord server.</SectionBody>
-      <Link href='https://discord.gg/wd67zUxPXn' target='_blank'>
+      <DiscordLink>
         <DiscordIcon src={DiscordLogo.src} alt='Join our Discord Server' />
-      </Link>
+      </DiscordLink>
     </ContentBlock>
   </div>
 )

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -24,7 +24,7 @@ const Homepage = () => (
     <ContentBlock isWide topMargin={40}>
       <NewsAndUpdates heading='Latest News & Updates' limit={3} showViewAllButton />
     </ContentBlock>
-    <ContentBlock topMargin={40} isWide>
+    <ContentBlock isWide topMargin={40}>
       <PageHeading>Join the Community</PageHeading>
       <BodyText variant='body' textAlign='center'>
         Click the button below to join our Discord server.

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,30 +1,39 @@
-import Typography from '@mui/material/Typography'
 import { ContentBlock } from '@atoms/ContentBlock'
-import { SectionBody, DiscordIcon } from '@styledPages/Homepage.styled'
+import { DiscordButtonContainer, DiscordIcon } from '@styledPages/Homepage.styled'
 import { OnlinePlayers } from '@organisms/OnlinePlayers'
 import { NewsAndUpdates } from '@organisms/NewsAndUpdates'
 import Link from 'next/link'
 import DiscordLogo from 'public/img/discord-512.webp'
 import { DiscordLink } from '@atoms/DiscordLink'
+import { PageHeading } from '@atoms/PageHeading'
+import { BodyText } from '@atoms/BodyText'
 
 const Homepage = () => (
   <div>
-    <OnlinePlayers />
     <ContentBlock isWide>
-      <Typography variant='h2'>Welcome back to 2003</Typography>
-      <SectionBody variant='body'>
+      <OnlinePlayers />
+    </ContentBlock>
+    <ContentBlock isWide topMargin={40}>
+      <PageHeading>Welcome back to 2003</PageHeading>
+      <BodyText variant='body' textAlign='center'>
         Neat F2P is an <em>upcoming</em> RuneScape Classic private server that aims to provide you with an RS1 F2P
         experience, featuring a F2P-only world and economy to explore and enjoy. For more information, check out the{' '}
         <Link href='/about'>About page</Link>.
-      </SectionBody>
+      </BodyText>
     </ContentBlock>
-    <NewsAndUpdates heading='Latest News & Updates' limit={3} showViewAllButton />
-    <ContentBlock isWide>
-      <Typography variant='h2'>Join the Community</Typography>
-      <SectionBody variant='body'>Click the button below to join our Discord server.</SectionBody>
-      <DiscordLink>
-        <DiscordIcon src={DiscordLogo.src} alt='Join our Discord Server' />
-      </DiscordLink>
+    <ContentBlock isWide topMargin={40}>
+      <NewsAndUpdates heading='Latest News & Updates' limit={3} showViewAllButton />
+    </ContentBlock>
+    <ContentBlock topMargin={40} isWide>
+      <PageHeading>Join the Community</PageHeading>
+      <BodyText variant='body' textAlign='center'>
+        Click the button below to join our Discord server.
+      </BodyText>
+      <DiscordButtonContainer>
+        <DiscordLink>
+          <DiscordIcon src={DiscordLogo.src} alt='Join our Discord Server' />
+        </DiscordLink>
+      </DiscordButtonContainer>
     </ContentBlock>
   </div>
 )

--- a/src/pages/news/index.tsx
+++ b/src/pages/news/index.tsx
@@ -2,7 +2,7 @@ import { ContentBlock } from '@atoms/ContentBlock'
 import { NewsAndUpdates } from '@organisms/NewsAndUpdates'
 
 const News = () => (
-  <ContentBlock topMargin={20}>
+  <ContentBlock>
     <NewsAndUpdates heading='News' />
   </ContentBlock>
 )

--- a/src/pages/news/post/[id]/index.tsx
+++ b/src/pages/news/post/[id]/index.tsx
@@ -37,7 +37,7 @@ const NewsPostDetail = () => {
   if (!newsPost?.title) return null
 
   return (
-    <ContentBlock topMargin={20}>
+    <ContentBlock>
       <NewsPostDetailItem newsPost={newsPost} />
     </ContentBlock>
   )

--- a/src/styledPages/About.styled.ts
+++ b/src/styledPages/About.styled.ts
@@ -1,9 +1,5 @@
 import { css, styled } from '@mui/material/styles'
-import Typography from '@mui/material/Typography'
 
-export const Paragraph = styled(Typography)`
-  margin-top: 20px;
-`
 export const FeatureList = styled('ul')(
   () => css`
     font-family: Saros;

--- a/src/styledPages/About.styled.ts
+++ b/src/styledPages/About.styled.ts
@@ -1,6 +1,24 @@
-import { styled } from '@mui/material/styles'
+import { css, styled } from '@mui/material/styles'
 import Typography from '@mui/material/Typography'
 
 export const Paragraph = styled(Typography)`
   margin-top: 20px;
 `
+export const FeatureList = styled('ul')(
+  () => css`
+    font-family: Saros;
+    font-size: 20px;
+    background-color: var(--gold-bg-color);
+    border: 2px dashed var(--gold-border-color);
+    padding-top: 16px;
+    padding-bottom: 16px;
+    padding-left: 56px; /* 40px for bullet + 8px */
+    padding-right: 16px;
+  `,
+)
+
+export const Feature = styled('li')(
+  () => css`
+    text-align: left;
+  `,
+)

--- a/src/styledPages/About.styled.ts
+++ b/src/styledPages/About.styled.ts
@@ -6,10 +6,7 @@ export const FeatureList = styled('ul')(
     font-size: 20px;
     background-color: var(--gold-bg-color);
     border: 2px dashed var(--gold-border-color);
-    padding-top: 16px;
-    padding-bottom: 16px;
-    padding-left: 56px; /* 40px for bullet + 8px */
-    padding-right: 16px;
+    padding: 16px 16px 16px 56px; /* Right: 40px for bullet points + 16px */
   `,
 )
 

--- a/src/styledPages/App.styled.ts
+++ b/src/styledPages/App.styled.ts
@@ -30,6 +30,6 @@ export const Logo = styled('img')(
 
 export const PaddedContainer = styled('div')(
   () => css`
-    padding: 20px;
+    padding: 40px 20px 60px;
   `,
 )

--- a/src/styledPages/Homepage.styled.ts
+++ b/src/styledPages/Homepage.styled.ts
@@ -1,11 +1,11 @@
-import { styled } from '@mui/material/styles'
-import Typography from '@mui/material/Typography'
+import { css, styled } from '@mui/material/styles'
 
-export const SectionBody = styled(Typography)`
-  margin-top: 1.25rem;
-`
+export const DiscordButtonContainer = styled('div')(
+  () => css`
+    margin-top: 40px;
+  `,
+)
 
 export const DiscordIcon = styled('img')`
-  margin-top: 1rem;
   width: 150px;
 `

--- a/src/styledPages/hiscores.styled.ts
+++ b/src/styledPages/hiscores.styled.ts
@@ -33,8 +33,8 @@ export const PlayerHiscoreTableContainer = styled('div')(
 
 export const HiscoresMenuItemList = styled('ul')(
   ({ theme }) => css`
-    background-color: rgba(218, 165, 32, 0.8);
-    border: 2px solid rgb(160, 82, 45);
+    background-color: var(--gold-bg-color);
+    border: 2px solid var(--gold-border-color);
     padding: 10px 16px;
     display: grid;
     grid-template-columns: 1fr 1fr;

--- a/src/theme/styles.css
+++ b/src/theme/styles.css
@@ -1,3 +1,22 @@
+:root {
+  --gold-bg-color: rgba(218, 165, 32, 0.8);
+  --gold-border-color: rgb(160, 82, 45);
+  --faded-blue-bg-color: #2055da;
+}
+
+body {
+  margin: 0;
+}
+
+a {
+  color: #800080;
+}
+
+button {
+  border: none;
+  background-color: transparent;
+}
+
 @font-face {
   font-family: 'Vinque';
   font-style: normal;
@@ -17,22 +36,4 @@
   font-style: normal;
   font-weight: normal;
   src: url('/fonts/SourceSansPro-Regular.ttf');
-}
-
-body {
-  margin: 0;
-}
-
-a {
-  color: #800080;
-}
-
-button {
-  border: none;
-  background-color: transparent;
-}
-
-:root {
-  --gold-bg-color: rgba(218, 165, 32, 0.8);
-  --gold-border-color: rgb(160, 82, 45);
 }

--- a/src/theme/styles.css
+++ b/src/theme/styles.css
@@ -31,3 +31,8 @@ button {
   border: none;
   background-color: transparent;
 }
+
+:root {
+  --gold-bg-color: rgba(218, 165, 32, 0.8);
+  --gold-border-color: rgb(160, 82, 45);
+}

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -95,14 +95,9 @@ theme = createTheme(theme, {
     },
     h2: {
       fontWeight: '600',
-      fontSize: '30px',
-      lineHeight: '30px',
+      fontSize: '36px',
+      lineHeight: '36px',
       fontFamily: 'Vinque',
-
-      [theme.breakpoints.up('tablet')]: {
-        fontSize: '36px',
-        lineHeight: '36px',
-      },
 
       [theme.breakpoints.up('desktop')]: {
         fontSize: '50px',


### PR DESCRIPTION
# What's Changed

- Removed alpha period info from How to Play page and added a details box
- Added `DiscordLink` atom component
- Cleaned up some pages
- Added `Callout` and `PageHeading` components
- Replaced all page headings with the new `PageHeading` component (this fixes spacing around main page headings to be equal)
- Fixed spacing issues for all pages (padding being uneven or just bad, etc)
- Added callout to `Hiscores` pages which replaces the body text
- Fixed spacing issues specific to some pages
- Replaced unique hex and rgb values with new CSS color variables
- Changed mobile sizing of `h2` typography