### PR TITLE
F2P-98 | Hiscores tweaks

### DIFF
--- a/src/components/atoms/HiscoresTable/HiscoresTable.styled.ts
+++ b/src/components/atoms/HiscoresTable/HiscoresTable.styled.ts
@@ -29,8 +29,13 @@ export const HiscoreTable = styled(Table, {
 )
 
 export const HiscoresTableRow = styled(TableRow)(
-  () => css`
-    border: 1px solid black;
+  ({ theme }) => css`
+    border-bottom: 1px solid black;
+    font-size: 14px;
+
+    ${theme.breakpoints.up('tablet')} {
+      font-size: 16px;
+    }
   `,
 )
 
@@ -39,7 +44,10 @@ export const HiscoreTableCell = styled(TableCell)(
     font-weight: 400;
     padding: 8px;
     border: 0;
-    border-right: 1px solid black;
+
+    &:not(:last-child) {
+      border-right: 1px solid black;
+    }
 
     ${theme.breakpoints.up('tablet')} {
       padding: 16px;

--- a/src/components/atoms/PlayerHiscoreTable/PlayerHiscoreTable.styled.ts
+++ b/src/components/atoms/PlayerHiscoreTable/PlayerHiscoreTable.styled.ts
@@ -1,11 +1,33 @@
 import { HiscoreTableCell } from '@atoms/HiscoresTable/HiscoresTable.styled'
-import { TableCell, TableRow } from '@mui/material'
+import { TableBody, TableCell, TableHead, TableRow } from '@mui/material'
 import { styled } from '@mui/material/styles'
 import { css } from '@mui/system'
 
 export const HiscoreTableRow = styled(TableRow)(
+  ({ theme }) => css`
+    display: grid;
+    grid-template-columns: 30% 20% 20% 30%;
+    font-size: 14px;
+
+    ${theme.breakpoints.up('tablet')} {
+      font-size: 16px;
+    }
+  `,
+)
+
+export const PlayerHiscoreTableHead = styled(TableHead)(
   () => css`
-    border: 1px solid black;
+    .MuiTableRow-root {
+      border-bottom: 1px solid black;
+    }
+  `,
+)
+
+export const PlayerHiscoreTableBody = styled(TableBody)(
+  () => css`
+    .MuiTableRow-root:not(:last-child) {
+      border-bottom: 1px solid black;
+    }
   `,
 )
 

--- a/src/components/atoms/PlayerHiscoreTable/PlayerHiscoreTable.tsx
+++ b/src/components/atoms/PlayerHiscoreTable/PlayerHiscoreTable.tsx
@@ -1,6 +1,13 @@
-import { TableContainer, TableBody, TableHead, Paper } from '@mui/material'
+import { TableContainer, Paper } from '@mui/material'
 import { HiscoreTable, HiscoreTableCell } from '@atoms/HiscoresTable/HiscoresTable.styled'
-import { ExperienceCell, HiscoreSkillIcon, HiscoreSkillTableCell, HiscoreTableRow } from './PlayerHiscoreTable.styled'
+import {
+  ExperienceCell,
+  HiscoreSkillIcon,
+  HiscoreSkillTableCell,
+  HiscoreTableRow,
+  PlayerHiscoreTableBody,
+  PlayerHiscoreTableHead,
+} from './PlayerHiscoreTable.styled'
 import { PlayerHiscoreRow } from '@globalTypes/Hiscores/PlayerHiscoreRow'
 
 type HiscoreTableProps = {
@@ -14,15 +21,15 @@ const PlayerHiscoreTable = (props: HiscoreTableProps) => {
   return (
     <TableContainer component={Paper} sx={{ boxShadow: 'none' }}>
       <HiscoreTable aria-label={`${accountName} Hiscore Table`}>
-        <TableHead>
+        <PlayerHiscoreTableHead>
           <HiscoreTableRow>
             <HiscoreTableCell sx={{ fontWeight: 700 }}>Skill</HiscoreTableCell>
             <HiscoreTableCell sx={{ fontWeight: 700 }}>Rank</HiscoreTableCell>
             <HiscoreTableCell sx={{ fontWeight: 700 }}>Level</HiscoreTableCell>
             <HiscoreTableCell sx={{ fontWeight: 700 }}>EXP</HiscoreTableCell>
           </HiscoreTableRow>
-        </TableHead>
-        <TableBody>
+        </PlayerHiscoreTableHead>
+        <PlayerHiscoreTableBody>
           {playerHiscores.map(playerHiscoreRow => (
             <HiscoreTableRow key={playerHiscoreRow.skill}>
               <HiscoreSkillTableCell>
@@ -34,7 +41,7 @@ const PlayerHiscoreTable = (props: HiscoreTableProps) => {
               <ExperienceCell>{playerHiscoreRow.exp}</ExperienceCell>
             </HiscoreTableRow>
           ))}
-        </TableBody>
+        </PlayerHiscoreTableBody>
       </HiscoreTable>
     </TableContainer>
   )

--- a/src/components/molecules/Spinner/Spinner.tsx
+++ b/src/components/molecules/Spinner/Spinner.tsx
@@ -7,11 +7,17 @@ type SpinnerProps = {
 }
 
 const HiscoresLoading = styled('div')(
-  () => css`
+  ({ theme }) => css`
     display: flex;
+    flex-basis: 100%;
     align-items: flex-start;
+    justify-content: center;
     margin: 0 auto;
     min-height: 1000px;
+
+    ${theme.breakpoints.up('tablet')} {
+      flex-basis: auto;
+    }
   `,
 )
 

--- a/src/pages/hiscores/player/[accountName].tsx
+++ b/src/pages/hiscores/player/[accountName].tsx
@@ -18,7 +18,10 @@ const PlayerHiscore = () => {
   const [isLoading, setIsLoading] = useState(true)
   const [hiscoresData, setHiscoresData] = useState<HiscoreDataRow[] | undefined>()
   const [playerHiscores, setPlayerHiscores] = useState<PlayerHiscoreRow[] | undefined>()
-  const accountName = query.accountName
+  const accountName = query.accountName as string
+
+  const isMatchingUser = (hiscoreDataRow: HiscoreDataRow) =>
+    hiscoreDataRow.username.toLowerCase() === accountName.toLowerCase()
 
   const getRank = (hiscoreType: HiscoreType) => {
     // Order hiscoresData by hiscoreType descending
@@ -28,14 +31,14 @@ const PlayerHiscore = () => {
     )
 
     // Then get the index of the current player in that sorted list (and if 0-based, add 1), that's the rank.
-    const rank = sortedHiscoresData?.findIndex(hiscoreDataRow => hiscoreDataRow.username === accountName)
+    const rank = sortedHiscoresData?.findIndex(isMatchingUser)
     if (rank === undefined) return 0
 
     return rank + 1
   }
 
   const getLevel = (hiscoreType: HiscoreType) => {
-    const playerHiscore = hiscoresData?.find(hiscoreDataRow => hiscoreDataRow.username === accountName)
+    const playerHiscore = hiscoresData?.find(isMatchingUser)
     const propName = hiscoreType === 'Overall' ? 'skill_total' : hiscoreType.toLowerCase()
 
     if (!playerHiscore) return 0
@@ -44,7 +47,7 @@ const PlayerHiscore = () => {
   }
 
   const getExp = (hiscoreType: HiscoreType) => {
-    const playerHiscore = hiscoresData?.find(hiscoreDataRow => hiscoreDataRow.username === accountName)
+    const playerHiscore = hiscoresData?.find(isMatchingUser)
 
     if (!playerHiscore) return '0'
 
@@ -69,9 +72,11 @@ const PlayerHiscore = () => {
   useEffect(() => {
     setIsLoading(true)
 
+    if (!accountName) return
+
     axios
       .post('/api/getPlayerHiscore', {
-        username: accountName,
+        username: accountName.toLowerCase(),
       })
       .then(response => {
         setHiscoresData(response?.data as HiscoreDataRow[])
@@ -79,7 +84,7 @@ const PlayerHiscore = () => {
       })
       .catch((error: string) => console.log(`Error getting player hiscore: ${error}`))
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [query.accountName])
+  }, [accountName])
 
   useEffect(() => {
     if (!hiscoresData) return
@@ -112,9 +117,7 @@ const PlayerHiscore = () => {
   return (
     <ContentBlock topMargin={20}>
       <Typography variant='h2'>{accountName}</Typography>
-      {typeof accountName !== 'string' ||
-      !playerHiscores ||
-      !hiscoresData?.find(hiscoreDataRow => hiscoreDataRow.username === accountName) ? (
+      {typeof accountName !== 'string' || !playerHiscores || !hiscoresData?.find(isMatchingUser) ? (
         <BodyText variant='body' textAlign='center'>
           No hiscore found for this player.
         </BodyText>


### PR DESCRIPTION
# What's Changed

- Player lookup now performs a case-insensitive search
- Fixed an issue with the spinner and one of the tables (skills menu or hiscores table) appearing on the same line on mobile when the hiscores are still loading
- Fixed a minor UI glitch with player hiscore table cells not being the same width on mobile