### PR TITLE
F2P-86 | Clicking on a news post image should open the news post

### DIFF
--- a/src/components/organisms/NewsPostListItem/NewsPostListItem.styled.ts
+++ b/src/components/organisms/NewsPostListItem/NewsPostListItem.styled.ts
@@ -1,9 +1,9 @@
 import { styled } from '@mui/material/styles'
 import { css } from '@mui/system'
 import ListItem from '@mui/material/ListItem'
-import ListItemAvatar from '@mui/material/ListItemAvatar'
 import { Typography } from '@mui/material'
 import { HoverUnderlineLink } from '@atoms/HoverUnderlineLink'
+import Link from 'next/link'
 
 export const NewsPostLi = styled(ListItem)(
   ({ theme }) => css`
@@ -17,7 +17,7 @@ export const NewsPostLi = styled(ListItem)(
   `,
 )
 
-export const NewsPostAvatar = styled(ListItemAvatar)(
+export const NewsPostAvatarLink = styled(Link)(
   ({ theme }) => css`
     width: 100%;
 

--- a/src/components/organisms/NewsPostListItem/NewsPostListItem.tsx
+++ b/src/components/organisms/NewsPostListItem/NewsPostListItem.tsx
@@ -1,5 +1,11 @@
-import { ListItemText, Typography, Divider } from '@mui/material'
-import { NewsPostLi, NewsPostAvatar, NewsPostTitleLink, NewsPostImage, NewsPostTitle } from './NewsPostListItem.styled'
+import { ListItemText, Typography, Divider, ListItemAvatar } from '@mui/material'
+import {
+  NewsPostLi,
+  NewsPostTitleLink,
+  NewsPostImage,
+  NewsPostTitle,
+  NewsPostAvatarLink,
+} from './NewsPostListItem.styled'
 import { NewsPostItemProps } from '@globalTypes/NewsPostItemProps'
 import { getPrettyDateStringFromISOString } from '@helpers/date/date'
 import ReadMore from '@molecules/ReadMore/ReadMore'
@@ -7,16 +13,19 @@ import { getNewsPostImageUrl } from '@helpers/imageUtils'
 
 const NewsPostListItem = (props: NewsPostItemProps) => {
   const { newsPost } = props
+  const newsPostUrl = `/news/post/${newsPost.id}`
 
   return (
     <div>
       <NewsPostLi alignItems='flex-start'>
-        <NewsPostAvatar>
-          <NewsPostImage src={getNewsPostImageUrl(newsPost.image)} alt={newsPost.alt} />
-        </NewsPostAvatar>
+        <NewsPostAvatarLink href={newsPostUrl}>
+          <ListItemAvatar>
+            <NewsPostImage src={getNewsPostImageUrl(newsPost.image)} alt={newsPost.alt} />
+          </ListItemAvatar>
+        </NewsPostAvatarLink>
         <ListItemText
           primary={
-            <NewsPostTitleLink href={`/news/post/${newsPost.id}`}>
+            <NewsPostTitleLink href={newsPostUrl}>
               <NewsPostTitle variant='body'>{newsPost.title}</NewsPostTitle>
             </NewsPostTitleLink>
           }
@@ -24,7 +33,7 @@ const NewsPostListItem = (props: NewsPostItemProps) => {
             <>
               <Typography variant='body'>{getPrettyDateStringFromISOString(newsPost.datePosted)}</Typography>
               <Typography variant='body' color='black' component='span'>
-                <ReadMore linkHref={`/news/post/${newsPost.id}`}>{newsPost.body}</ReadMore>
+                <ReadMore linkHref={newsPostUrl}>{newsPost.body}</ReadMore>
               </Typography>
             </>
           }


### PR DESCRIPTION

# What's Changed

- Made news post list item images clickable, to the new posts page