### PR TITLE
Temporarily disable game account creations

### DIFF
--- a/src/pages/account/game-accounts/create/index.tsx
+++ b/src/pages/account/game-accounts/create/index.tsx
@@ -145,6 +145,17 @@ const CreateGameAccount = () => {
     return <Spinner />
   }
 
+  if (true) {
+    return (
+      <ContentBlock>
+        <PageHeading>Temporarily Disabled</PageHeading>
+        <BodyText variant='body' textAlign='center'>
+          Game account creations are temporarily disabled until further notice.
+        </BodyText>
+      </ContentBlock>
+    )
+  }
+
   if (!UserIsLoggedIn(user)) {
     return <NotLoggedIn />
   }
@@ -156,7 +167,7 @@ const CreateGameAccount = () => {
   return (
     <ContentBlock>
       <PageHeading>Create Game Account</PageHeading>
-      <BodyText variant='body' textAlign='left'>
+      <BodyText variant='body'>
         Game account names must be 12 characters or less. You are allowed spaces within your name, but any spaces at the
         start or end of your name will be removed upon account creation.
       </BodyText>

--- a/src/pages/account/game-accounts/index.tsx
+++ b/src/pages/account/game-accounts/index.tsx
@@ -69,7 +69,10 @@ const GameAccountsPage = () => {
         showRenameModal={showRenameModal}
         showPasswordModal={showPasswordModal}
       />
-      <FormButton variant='contained' onClick={handleCreateAccount}>
+      <BodyText variant='body' textAlign='center'>
+        Game account creations are temporarily disabled until further notice.
+      </BodyText>
+      <FormButton variant='contained' onClick={handleCreateAccount} disabled>
         Create Account
       </FormButton>
     </ContentBlock>


### PR DESCRIPTION
# What's Changed

- Temporarily disabled game account creations (to be used after the lag test event concludes, until a specific date when real game account creations will be allowed - probably date before launch)
