### PR TITLE
F2P-83 | Potentially add Pagination to Hiscores if the need arises

### DIFF
--- a/src/components/atoms/HiscoresTable/HiscoresTable.styled.ts
+++ b/src/components/atoms/HiscoresTable/HiscoresTable.styled.ts
@@ -69,10 +69,6 @@ export const HiscoreTableCell = styled(TableCell)(
 export const HiscoreUsername = styled(HoverUnderlineLink)(
   () => css`
     color: black;
-
-    :hover {
-      cursor: pointer;
-    }
   `,
 )
 

--- a/src/components/atoms/HiscoresTable/HiscoresTable.styled.ts
+++ b/src/components/atoms/HiscoresTable/HiscoresTable.styled.ts
@@ -1,14 +1,25 @@
 import { ExtendedTableContainerProps } from '@globalTypes/MUI/ExtendedTableContainerProps'
-import { Table, TableCell, TableContainer, TableRow } from '@mui/material'
+import { Pagination, Table, TableCell, TableContainer, TableRow } from '@mui/material'
 import { styled } from '@mui/material/styles'
 import { css } from '@mui/system'
+import VerticalAlignTopIcon from '@mui/icons-material/VerticalAlignTop'
+import { HoverUnderlineLink } from '@atoms/HoverUnderlineLink'
+
+export const RootContainer = styled('div')(
+  () => css`
+    width: 100%;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+  `,
+)
 
 export const HiscoreTableContainer = styled(TableContainer)<ExtendedTableContainerProps>(
   ({ theme }) => css`
     box-shadow: none;
 
     ${theme.breakpoints.up('tablet')} {
-      flex-basis: calc(70% - 36px);
+      flex-basis: 100%;
     }
 
     ${theme.breakpoints.up('desktop')} {
@@ -55,14 +66,51 @@ export const HiscoreTableCell = styled(TableCell)(
   `,
 )
 
-export const HiscoreUsername = styled('a')(
+export const HiscoreUsername = styled(HoverUnderlineLink)(
   () => css`
     color: black;
-    text-decoration: none;
 
     :hover {
-      text-decoration: underline;
       cursor: pointer;
+    }
+  `,
+)
+
+export const HiscoresControls = styled('div')(
+  () => css`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    column-gap: 30px;
+    margin-top: 40px;
+  `,
+)
+
+export const HiscoresPagination = styled(Pagination)(
+  () => css`
+    & .MuiPaginationItem-text {
+      font-family: Verdana;
+      font-size: 14px;
+    }
+
+    & .MuiPaginationItem-root.Mui-selected {
+      background-color: var(--faded-blue-bg-color);
+    }
+
+    & .MuiPaginationItem-root:not(.Mui-selected) {
+      color: black;
+    }
+  `,
+)
+
+export const ScrollToTopButton = styled(VerticalAlignTopIcon)(
+  () => css`
+    cursor: pointer;
+    width: 24px;
+    height: 24px;
+
+    &:hover {
+      color: var(--faded-blue-bg-color);
     }
   `,
 )

--- a/src/components/atoms/HiscoresTable/HiscoresTable.tsx
+++ b/src/components/atoms/HiscoresTable/HiscoresTable.tsx
@@ -2,126 +2,117 @@ import { HiscoreDataRow } from '@globalTypes/Database/HiscoreDataRow'
 import { HiscoreType } from '@globalTypes/Hiscores/HiscoreType'
 import { TableBody, TableHead, Paper } from '@mui/material'
 import {
+  RootContainer,
+  HiscoreTableContainer,
   HiscoreTable,
   HiscoreTableCell,
-  HiscoreTableContainer,
   HiscoreUsername,
   HiscoresTableRow,
+  HiscoresPagination,
+  HiscoresControls,
+  ScrollToTopButton,
 } from './HiscoresTable.styled'
-import { getTotalExp } from '@helpers/hiscores/hiscoresUtils'
+import { convertExp, getTotalExp } from '@helpers/hiscores/hiscoresUtils'
+import { useEffect } from 'react'
+import { useRouter } from 'next/router'
+import { push } from '@helpers/router'
 
 type HiscoresTableProps = {
   hiscores: HiscoreDataRow[]
   hiscoreType: HiscoreType
+  page: number
+  setPage: (value: number) => void
 }
 
 const HiscoresTable = (props: HiscoresTableProps) => {
-  const { hiscores, hiscoreType } = props
+  const { hiscores, hiscoreType, page, setPage } = props
+  const router = useRouter()
+  const resultsPerPage = 20
+  const pageCount = Math.ceil(hiscores.length / resultsPerPage)
+  const startingRecord = page === 1 ? 0 : (page - 1) * resultsPerPage
+  const endingRecord = page == 1 ? resultsPerPage : startingRecord + resultsPerPage
+  let rank = startingRecord
 
   const getHiscoreValue = (hiscore: HiscoreDataRow) => {
     switch (hiscoreType) {
       case 'Overall':
         return hiscore.skill_total
-      case 'Attack':
-        return hiscore.attack
-      case 'Defense':
-        return hiscore.defense
-      case 'Strength':
-        return hiscore.strength
-      case 'Hits':
-        return hiscore.hits
-      case 'Ranged':
-        return hiscore.ranged
-      case 'Prayer':
-        return hiscore.prayer
-      case 'Magic':
-        return hiscore.magic
-      case 'Cooking':
-        return hiscore.cooking
-      case 'Woodcut':
-        return hiscore.woodcut
-      case 'Fishing':
-        return hiscore.fishing
-      case 'Firemaking':
-        return hiscore.firemaking
-      case 'Crafting':
-        return hiscore.crafting
-      case 'Smithing':
-        return hiscore.smithing
-      case 'Mining':
-        return hiscore.mining
+      default:
+        return hiscore[(hiscoreType as string).toLowerCase() as keyof typeof hiscore]
     }
-  }
-
-  const convertXP = (skillXP: number) => {
-    // Open RSC Core Framework experience numbers are 4 times what the actual RS exp number is.
-    return Math.round(skillXP / 4).toLocaleString()
   }
 
   const getHiscoreSkillXP = (hiscore: HiscoreDataRow) => {
     switch (hiscoreType) {
       case 'Overall':
         return getTotalExp(hiscore)
-      case 'Attack':
-        return hiscore.attackxp
-      case 'Defense':
-        return hiscore.defensexp
-      case 'Strength':
-        return hiscore.strengthxp
-      case 'Hits':
-        return hiscore.hitsxp
-      case 'Ranged':
-        return hiscore.rangedxp
-      case 'Prayer':
-        return hiscore.prayerxp
-      case 'Magic':
-        return hiscore.magicxp
-      case 'Cooking':
-        return hiscore.cookingxp
-      case 'Woodcut':
-        return hiscore.woodcutxp
-      case 'Fishing':
-        return hiscore.fishingxp
-      case 'Firemaking':
-        return hiscore.firemakingxp
-      case 'Crafting':
-        return hiscore.craftingxp
-      case 'Smithing':
-        return hiscore.smithingxp
-      case 'Mining':
-        return hiscore.miningxp
+      default:
+        return hiscore[`${(hiscoreType as string).toLowerCase()}xp` as keyof typeof hiscore] as number
     }
   }
 
+  const handlePageChange = (event: React.ChangeEvent<unknown>, value: number) => {
+    setPage(value)
+    router.query.page = value.toString()
+    push(router, '/hiscores', router.query)
+  }
+
+  const handleScrollToTop = () => {
+    window.scrollTo({ top: 525, behavior: 'smooth' })
+  }
+
+  useEffect(() => {
+    router.query.page = page.toString()
+    push(router, '/hiscores', router.query)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [page])
+
   return (
-    <HiscoreTableContainer component={Paper}>
-      <HiscoreTable aria-label={`${hiscoreType} Hiscores Table`}>
-        <TableHead>
-          <HiscoresTableRow>
-            <HiscoreTableCell sx={{ fontWeight: 700 }}>Rank</HiscoreTableCell>
-            <HiscoreTableCell sx={{ fontWeight: 700 }}>Name</HiscoreTableCell>
-            <HiscoreTableCell sx={{ fontWeight: 700 }}>Level</HiscoreTableCell>
-            <HiscoreTableCell sx={{ fontWeight: 700 }}>EXP</HiscoreTableCell>
-          </HiscoresTableRow>
-        </TableHead>
-        <TableBody>
-          {hiscores?.map((hiscoreRow, index) => (
-            <HiscoresTableRow key={hiscoreRow.username}>
-              <HiscoreTableCell component='th' scope='row'>
-                {index + 1}
-              </HiscoreTableCell>
-              <HiscoreTableCell>
-                <HiscoreUsername href={`/hiscores/player/${hiscoreRow.username}`}>
-                  {hiscoreRow.username}
-                </HiscoreUsername>
-              </HiscoreTableCell>
-              <HiscoreTableCell>{getHiscoreValue(hiscoreRow)}</HiscoreTableCell>
-              <HiscoreTableCell>{convertXP(getHiscoreSkillXP(hiscoreRow))}</HiscoreTableCell>
+    <RootContainer>
+      <HiscoreTableContainer component={Paper}>
+        <HiscoreTable aria-label={`${hiscoreType} Hiscores Table`}>
+          <TableHead>
+            <HiscoresTableRow>
+              <HiscoreTableCell sx={{ fontWeight: 700 }}>Rank</HiscoreTableCell>
+              <HiscoreTableCell sx={{ fontWeight: 700 }}>Name</HiscoreTableCell>
+              <HiscoreTableCell sx={{ fontWeight: 700 }}>Level</HiscoreTableCell>
+              <HiscoreTableCell sx={{ fontWeight: 700 }}>EXP</HiscoreTableCell>
             </HiscoresTableRow>
-          ))}
-        </TableBody>
-      </HiscoreTable>
-    </HiscoreTableContainer>
+          </TableHead>
+          <TableBody>
+            {hiscores?.slice(startingRecord, endingRecord).map((hiscoreRow, index) => {
+              rank++
+              return (
+                <HiscoresTableRow key={hiscoreRow.username}>
+                  <HiscoreTableCell component='th' scope='row'>
+                    {startingRecord === 0 ? index + 1 : rank}
+                  </HiscoreTableCell>
+                  <HiscoreTableCell>
+                    <HiscoreUsername href={`/hiscores/player/${hiscoreRow.username}`}>
+                      {hiscoreRow.username}
+                    </HiscoreUsername>
+                  </HiscoreTableCell>
+                  <HiscoreTableCell>{getHiscoreValue(hiscoreRow)}</HiscoreTableCell>
+                  <HiscoreTableCell>{convertExp(getHiscoreSkillXP(hiscoreRow))}</HiscoreTableCell>
+                </HiscoresTableRow>
+              )
+            })}
+          </TableBody>
+        </HiscoreTable>
+      </HiscoreTableContainer>
+      {pageCount > 1 && (
+        <HiscoresControls>
+          <HiscoresPagination
+            page={page ?? 1}
+            count={pageCount}
+            shape='rounded'
+            color='primary'
+            onChange={handlePageChange}
+          />
+          <ScrollToTopButton onClick={handleScrollToTop} />
+        </HiscoresControls>
+      )}
+    </RootContainer>
   )
 }
 

--- a/src/components/atoms/PlayerHiscoreTable/PlayerHiscoreTable.styled.ts
+++ b/src/components/atoms/PlayerHiscoreTable/PlayerHiscoreTable.styled.ts
@@ -1,4 +1,5 @@
 import { HiscoreTableCell } from '@atoms/HiscoresTable/HiscoresTable.styled'
+import { HoverUnderlineLink } from '@atoms/HoverUnderlineLink'
 import { TableBody, TableCell, TableHead, TableRow } from '@mui/material'
 import { styled } from '@mui/material/styles'
 import { css } from '@mui/system'
@@ -55,6 +56,12 @@ export const HiscoreSkillIcon = styled('img')(
       margin-right: 8px;
       background-color: transparent;
     }
+  `,
+)
+
+export const SkillLink = styled(HoverUnderlineLink)(
+  () => css`
+    color: black;
   `,
 )
 

--- a/src/components/atoms/PlayerHiscoreTable/PlayerHiscoreTable.tsx
+++ b/src/components/atoms/PlayerHiscoreTable/PlayerHiscoreTable.tsx
@@ -7,6 +7,7 @@ import {
   HiscoreTableRow,
   PlayerHiscoreTableBody,
   PlayerHiscoreTableHead,
+  SkillLink,
 } from './PlayerHiscoreTable.styled'
 import { PlayerHiscoreRow } from '@globalTypes/Hiscores/PlayerHiscoreRow'
 
@@ -34,7 +35,7 @@ const PlayerHiscoreTable = (props: HiscoreTableProps) => {
             <HiscoreTableRow key={playerHiscoreRow.skill}>
               <HiscoreSkillTableCell>
                 <HiscoreSkillIcon src={`/img/skills/${playerHiscoreRow.skill}.png`} alt='' />
-                <span>{playerHiscoreRow.skill}</span>
+                <SkillLink href={`/hiscores?skill=${playerHiscoreRow.skill}`}>{playerHiscoreRow.skill}</SkillLink>
               </HiscoreSkillTableCell>
               <HiscoreTableCell>{playerHiscoreRow.rank === 0 ? '--' : playerHiscoreRow.rank}</HiscoreTableCell>
               <HiscoreTableCell>{playerHiscoreRow.level}</HiscoreTableCell>

--- a/src/components/molecules/PlayerLookup/PlayerLookup.styled.ts
+++ b/src/components/molecules/PlayerLookup/PlayerLookup.styled.ts
@@ -47,14 +47,14 @@ export const PlayerNameField = styled(Field)(
 export const LookupSubmitButton = styled(FormButton)(
   ({ theme }) => css`
     background-color: var(--faded-blue-bg-color);
-    margin-top: 20px;
+    margin: 20px 0 12px;
 
     :hover {
       background-color: darkblue;
     }
 
     ${theme.breakpoints.up('tablet')} {
-      margin-top: 40px;
+      margin: 40px 0 35px;
     }
   `,
 )

--- a/src/helpers/hiscores/hiscoresUtils.ts
+++ b/src/helpers/hiscores/hiscoresUtils.ts
@@ -1,4 +1,5 @@
 import { HiscoreDataRow } from '@globalTypes/Database/HiscoreDataRow'
+import { HiscoresSortField } from '@globalTypes/Database/HiscoresSortField'
 
 export const getTotalExp = (hiscoreRow: HiscoreDataRow) =>
   hiscoreRow.attackxp +
@@ -19,4 +20,14 @@ export const getTotalExp = (hiscoreRow: HiscoreDataRow) =>
 export const convertExp = (skillXP: number) => {
   // Open RSC Core Framework experience numbers are 4 times what the actual RS exp number is.
   return Math.round(skillXP / 4).toLocaleString()
+}
+
+export const isNotBaselineExp = (hiscore: HiscoreDataRow, propName: string) => {
+  if (propName === 'skill_total') {
+    return getTotalExp(hiscore) > 4000
+  } else if (propName === 'hitsxp') {
+    return hiscore.hitsxp > 4000
+  } else {
+    return hiscore[propName as keyof HiscoresSortField] > 0
+  }
 }

--- a/src/helpers/router.ts
+++ b/src/helpers/router.ts
@@ -1,0 +1,15 @@
+import { NextRouter } from 'next/router'
+import { ParsedUrlQuery } from 'querystring'
+
+/** Runs Next.js `router.push` but with the correct arguments, so the scroll position isn't lost
+ *  and there aren't weird console warnings. */
+export const push = (router: NextRouter, pathname: string, query: ParsedUrlQuery) => {
+  router.push(
+    {
+      pathname,
+      query,
+    },
+    undefined,
+    { scroll: false },
+  )
+}

--- a/src/hooks/useHiscores.ts
+++ b/src/hooks/useHiscores.ts
@@ -1,7 +1,7 @@
 import { HiscoreDataRow } from '@globalTypes/Database/HiscoreDataRow'
 import { HiscoresSortField } from '@globalTypes/Database/HiscoresSortField'
 import { HiscoreType } from '@globalTypes/Hiscores/HiscoreType'
-import { getTotalExp } from '@helpers/hiscores/hiscoresUtils'
+import { isNotBaselineExp } from '@helpers/hiscores/hiscoresUtils'
 import axios from 'axios'
 import { Dispatch, SetStateAction, useEffect, useState } from 'react'
 
@@ -47,18 +47,9 @@ const useHiscores = (hiscoreType: HiscoreType, setIsLoading: Dispatch<SetStateAc
   }, [])
 
   useEffect(() => {
+    const propName = hiscoreType === 'Overall' ? 'skill_total' : `${hiscoreType.toLowerCase()}xp`
     const sortedHiscores = rawHiscores
-      ?.filter(hiscoreRow => {
-        // Omit hiscore records with baseline experience
-        switch (hiscoreType) {
-          case 'Overall':
-            return getTotalExp(hiscoreRow) > 4000
-          case 'Hits':
-            return hiscoreRow.hitsxp > 4000
-          default:
-            return hiscoreRow[`${hiscoreType.toLowerCase()}xp` as keyof HiscoresSortField] > 0
-        }
-      })
+      ?.filter(hiscoreRow => isNotBaselineExp(hiscoreRow, propName))
       .sort(compareHiscores)
 
     setHiscores(sortedHiscores)

--- a/src/pages/hiscores/index.tsx
+++ b/src/pages/hiscores/index.tsx
@@ -10,17 +10,31 @@ import { Spinner } from '@molecules/Spinner'
 import { PlayerLookup } from '@molecules/PlayerLookup'
 import { PageHeading } from '@atoms/PageHeading'
 import { TextBanner } from '@atoms/TextBanner'
+import { push } from '@helpers/router'
 
 const Hiscores = () => {
   const [isLoading, setIsLoading] = useState(true)
   const router = useRouter()
   const { query } = router
-  const isHiscoreType = (x: any): x is HiscoreType => HiscoreTypes.includes(x)
+  const [hiscoresPage, setHiscoresPage] = useState(1)
+  const isHiscoreType = (x: string): x is HiscoreType => HiscoreTypes.includes(x as HiscoreType)
   const [hiscoreType, setHiscoreType] = useState<HiscoreType>('Overall')
   const hiscores = useHiscores(hiscoreType, setIsLoading)
 
+  const handleMenuItemClick = (hiscoreType: HiscoreType) => {
+    setHiscoreType(hiscoreType)
+    setHiscoresPage(1)
+    router.query.page = '1'
+    router.query.skill = hiscoreType
+    push(router, '/hiscores', router.query)
+  }
+
   useEffect(() => {
-    setHiscoreType(isHiscoreType(query?.skill) ? query?.skill : 'Overall')
+    if (query.skill) {
+      setHiscoreType(typeof query.skill === 'string' && isHiscoreType(query.skill) ? query.skill : 'Overall')
+    } else {
+      setHiscoreType('Overall')
+    }
   }, [query])
 
   return (
@@ -33,11 +47,16 @@ const Hiscores = () => {
         </span>
       </TextBanner>
       <HiscoresPageContainer>
-        <HiscoresMenu hiscoreType={hiscoreType} buttonOnClick={setHiscoreType} />
+        <HiscoresMenu hiscoreType={hiscoreType} buttonOnClick={handleMenuItemClick} />
         {isLoading || !hiscores ? (
           <Spinner hiscores />
         ) : (
-          <HiscoresTable hiscores={hiscores} hiscoreType={hiscoreType} />
+          <HiscoresTable
+            hiscores={hiscores}
+            hiscoreType={hiscoreType}
+            page={query.page ? Number(query.page) : hiscoresPage}
+            setPage={setHiscoresPage}
+          />
         )}
         <PlayerLookup />
       </HiscoresPageContainer>

--- a/src/pages/hiscores/player/[accountName].tsx
+++ b/src/pages/hiscores/player/[accountName].tsx
@@ -8,7 +8,7 @@ import { HiscoreDataRow } from '@globalTypes/Database/HiscoreDataRow'
 import { HiscoresSortField } from '@globalTypes/Database/HiscoresSortField'
 import { HiscoreType } from '@globalTypes/Hiscores/HiscoreType'
 import { PlayerHiscoreRow } from '@globalTypes/Hiscores/PlayerHiscoreRow'
-import { convertExp, getTotalExp } from '@helpers/hiscores/hiscoresUtils'
+import { convertExp, getTotalExp, isNotBaselineExp } from '@helpers/hiscores/hiscoresUtils'
 import { Spinner } from '@molecules/Spinner'
 import { PlayerHiscoreTableContainer } from '@styledPages/hiscores.styled'
 import axios from 'axios'
@@ -28,9 +28,9 @@ const PlayerHiscore = () => {
   const getRank = (hiscoreType: HiscoreType) => {
     // Order hiscoresData by hiscoreType descending
     const propName = hiscoreType === 'Overall' ? 'skill_total' : `${hiscoreType.toLowerCase()}xp`
-    const sortedHiscoresData = hiscoresData?.sort(
-      (obj1, obj2) => obj2[propName as keyof HiscoresSortField] - obj1[propName as keyof HiscoresSortField],
-    )
+    const sortedHiscoresData = hiscoresData
+      ?.sort((obj1, obj2) => obj2[propName as keyof HiscoresSortField] - obj1[propName as keyof HiscoresSortField])
+      .filter(hiscore => isNotBaselineExp(hiscore, propName))
 
     // Then get the index of the current player in that sorted list (and if 0-based, add 1), that's the rank.
     const rank = sortedHiscoresData?.findIndex(isMatchingUser)


### PR DESCRIPTION
# What's Changed

- Implemented pagination and scroll to top controls for Hiscores
- Implemented query strings for current skill and hiscore page so hiscore pages can be deep linked
- Added skill links to player hiscore table for easier navigation
- Fixed issue with some player hiscore table ranks being incorrect due to accounts with baseline exp being factored into the rank
- Added `isNotBaselineExp` helper which is used by both hiscore tables now
- Fixed some minor spacing issues with PlayerLookup
- Minor refactoring
