### PR TITLE
F2P-72 | We should allow special characters in game account passwords but replace with underscore like RSC does

### DIFF
--- a/src/components/organisms/PasswordModal/PasswordModal.tsx
+++ b/src/components/organisms/PasswordModal/PasswordModal.tsx
@@ -4,7 +4,7 @@ import axios from 'axios'
 import { Field } from '@atoms/Field'
 import { Modal } from '@molecules/Modal'
 import { hashPassword } from '@helpers/password'
-import { gameAccountPasswordIsValid } from '@helpers/string/stringUtils'
+import { sanitizeRunescapePassword } from '@helpers/string/stringUtils'
 
 type PasswordModalProps = {
   account: PlayerDataRow
@@ -48,14 +48,11 @@ const PasswordModal = (props: PasswordModalProps) => {
       return
     }
 
-    // Make sure password is valid
-    if (!gameAccountPasswordIsValid(newPassword)) {
-      setValidationError('Game account passwords can only have letters, numbers and underscores.')
-      return
-    }
+    // Fix password so RSC recognizes it
+    const fixedPassword = sanitizeRunescapePassword(newPassword)
 
     // Hash new password.
-    const { hashedPassword } = hashPassword(newPassword, true)
+    const { hashedPassword } = hashPassword(fixedPassword, true)
 
     axios
       .post('/api/updateGameAccountPassword', {
@@ -88,8 +85,20 @@ const PasswordModal = (props: PasswordModalProps) => {
       renderFields={() => (
         <>
           <Field type='text' label='Account' value={account.username} disabled />
-          <Field type='password' label='New Password' required onChange={handleNewPasswordChange} />
-          <Field type='password' label='Confirm New Password' required onChange={handleConfirmNewPasswordChange} />
+          <Field
+            type='password'
+            label='New Password'
+            required
+            onChange={handleNewPasswordChange}
+            inputProps={{ maxLength: 20 }}
+          />
+          <Field
+            type='password'
+            label='Confirm New Password'
+            required
+            onChange={handleConfirmNewPasswordChange}
+            inputProps={{ maxLength: 20 }}
+          />
         </>
       )}
       formValidationError={validationError}

--- a/src/helpers/string/stringUtils.ts
+++ b/src/helpers/string/stringUtils.ts
@@ -4,14 +4,5 @@ export const cleanInputString = (text: string) => {
   return text.replace(/'/g, "\\'")
 }
 
-/** Checks if game account password string is valid.
- * For now, we only allow game account passwords with letters, numbers and underscores. */
-export const gameAccountPasswordIsValid = (password: string) => {
-  const validPasswordMatches = password.match(/^[a-zA-Z0-9_]+$/g)
-
-  if (!validPasswordMatches || !validPasswordMatches?.[0]) {
-    return false
-  }
-
-  return true
-}
+/** Fixes passwords so RSC recognizes them, by replacing special characters with underscores. */
+export const sanitizeRunescapePassword = (password: string) => password.replace(/[^A-Z0-9]/gi, '_')

--- a/src/pages/account/game-accounts/create/index.tsx
+++ b/src/pages/account/game-accounts/create/index.tsx
@@ -13,9 +13,9 @@ import useAuthentication from '@hooks/useAuthentication'
 import { UserIsLoggedIn } from '@helpers/users/users'
 import { NotLoggedIn } from '@molecules/NotLoggedIn'
 import { Spinner } from '@molecules/Spinner'
-import { gameAccountPasswordIsValid } from '@helpers/string/stringUtils'
 import { PageHeading } from '@atoms/PageHeading'
 import { BannedText } from 'src/data/BannedText'
+import { sanitizeRunescapePassword } from '@helpers/string/stringUtils'
 
 const CreateGameAccount = () => {
   const [loading, setLoading] = useState(true)
@@ -79,12 +79,6 @@ const CreateGameAccount = () => {
       return
     }
 
-    if (!gameAccountPasswordIsValid(password)) {
-      setSubmitDisabled(false)
-      setValidationError('Game account passwords can only have letters, numbers and underscores.')
-      return
-    }
-
     // Check if account name already exists. Check with both values in lower case.
     if (currentAccountNames.includes(sanitizedAccountName.toLowerCase())) {
       setSubmitDisabled(false)
@@ -92,8 +86,11 @@ const CreateGameAccount = () => {
       return
     }
 
+    // Fix password so RSC recognizes it
+    const fixedPassword = sanitizeRunescapePassword(password)
+
     // Hash password
-    const { hashedPassword } = hashPassword(password, true)
+    const { hashedPassword } = hashPassword(fixedPassword, true)
 
     axios.get('https://api.ipify.org/?format=json').then(response => {
       // Create account
@@ -188,6 +185,7 @@ const CreateGameAccount = () => {
           type='password'
           variant='standard'
           onChange={handlePasswordChange}
+          inputProps={{ maxLength: 20 }}
         />
         <Field
           required
@@ -196,6 +194,7 @@ const CreateGameAccount = () => {
           type='password'
           variant='standard'
           onChange={handleConfirmPasswordChange}
+          inputProps={{ maxLength: 20 }}
         />
         <FieldValidationMessage>{validationError}</FieldValidationMessage>
         <FormButton variant='contained' type='submit' disabled={submitDisabled}>


### PR DESCRIPTION
# What's Changed

- Swapped out password validation for password fixing so users can have special characters in their game account passwords
- Enforced game account password max length to be 20 since the game client does not let you type in more than that amount