### PR TITLE
F2P-117 | Bug Type dropdown color issue

### DIFF
--- a/src/styledPages/ReportABug.styled.ts
+++ b/src/styledPages/ReportABug.styled.ts
@@ -22,7 +22,7 @@ export const BugTypeMenuItem = styled(MenuItem)(
       background-color: var(--faded-green-bg-color);
     }
 
-    &.Mui-selected {
+    &&.Mui-selected {
       background-color: lightgray;
 
       &:hover {


### PR DESCRIPTION

# What's Changed

- Fixed Bug Type dropdown default selected item background color by increasing specificity of `.Mui-selected` selector

