### PR TITLE
F2P-112 | Read More links look bad again

### DIFF
--- a/src/components/atoms/MainNavigation/MainNavigation.styled.ts
+++ b/src/components/atoms/MainNavigation/MainNavigation.styled.ts
@@ -30,8 +30,8 @@ export const NavLink = styled(Link, {
     color: white;
     text-decoration: none;
     border: 2px solid;
-    border-color: ${isActive ? '#800080' : 'green'};
-    background-color: ${isActive ? '#800080' : 'green'};
+    border-color: ${isActive ? 'purple' : 'green'};
+    background-color: ${isActive ? 'purple' : 'green'};
     border-radius: 20px;
     padding: 8px;
 

--- a/src/components/molecules/ReadMore/ReadMore.tsx
+++ b/src/components/molecules/ReadMore/ReadMore.tsx
@@ -13,8 +13,8 @@ const ReadMore = (props: ReadMoreProps) => {
     <Text>
       {children.length > 300 ? (
         <>
-          {parse(`${children.slice(0, 300)}...`)} &nbsp;
-          <ReadMoreLink href={linkHref}>Read More</ReadMoreLink>
+          {parse(`${children.slice(0, 300)}...`)}
+          <ReadMoreLink href={linkHref}>Read post {'>>'}</ReadMoreLink>
         </>
       ) : (
         parse(children)

--- a/src/theme/styles.css
+++ b/src/theme/styles.css
@@ -10,7 +10,7 @@ body {
 }
 
 a {
-  color: #800080;
+  color: green;
 }
 
 button {


### PR DESCRIPTION
# What's Changed

- Changed global link color to `green`
- Removed non-breakable space before the Read More link
- Renamed `Read More` to `Read post >>`
- Changed some `#800080` hex references to `purple` to be consistent since they are the same value
