### PR TITLE
F2P-119 | If two players on hiscores have same level, the player with more EXP should get the higher rank

### DIFF
--- a/src/hooks/useHiscores.ts
+++ b/src/hooks/useHiscores.ts
@@ -30,16 +30,14 @@ const useHiscores = (hiscoreType: HiscoreType, setIsLoading: Dispatch<SetStateAc
       return 1
     }
 
-    if (playerOne[fieldName] === playerTwo[fieldName]) {
+    if (playerOne[fieldName] === playerTwo[fieldName] && fieldName === 'skill_total') {
       // If this is Overall, we need to compare total EXP and give the tie breaker to the player with more EXP.
-      if (fieldName === 'skill_total') {
-        if (getTotalExp(playerOne) > getTotalExp(playerTwo)) {
-          return -1
-        }
+      if (getTotalExp(playerOne) > getTotalExp(playerTwo)) {
+        return -1
+      }
 
-        if (getTotalExp(playerOne) < getTotalExp(playerTwo)) {
-          return 1
-        }
+      if (getTotalExp(playerOne) < getTotalExp(playerTwo)) {
+        return 1
       }
     }
 

--- a/src/hooks/useHiscores.ts
+++ b/src/hooks/useHiscores.ts
@@ -1,7 +1,7 @@
 import { HiscoreDataRow } from '@globalTypes/Database/HiscoreDataRow'
 import { HiscoresSortField } from '@globalTypes/Database/HiscoresSortField'
 import { HiscoreType } from '@globalTypes/Hiscores/HiscoreType'
-import { isNotBaselineExp } from '@helpers/hiscores/hiscoresUtils'
+import { getTotalExp, isNotBaselineExp } from '@helpers/hiscores/hiscoresUtils'
 import axios from 'axios'
 import { Dispatch, SetStateAction, useEffect, useState } from 'react'
 
@@ -28,6 +28,19 @@ const useHiscores = (hiscoreType: HiscoreType, setIsLoading: Dispatch<SetStateAc
 
     if (playerOne[fieldName] < playerTwo[fieldName]) {
       return 1
+    }
+
+    if (playerOne[fieldName] === playerTwo[fieldName]) {
+      // If this is Overall, we need to compare total EXP and give the tie breaker to the player with more EXP.
+      if (fieldName === 'skill_total') {
+        if (getTotalExp(playerOne) > getTotalExp(playerTwo)) {
+          return -1
+        }
+
+        if (getTotalExp(playerOne) < getTotalExp(playerTwo)) {
+          return 1
+        }
+      }
     }
 
     return 0


### PR DESCRIPTION
# What's Changed

- Fixed issue in Overall hiscores where if two players have the same total, it was not showing the player with the most experience as the highest rank of those players

# Fixes

https://github.com/aldrichdev/neatf2p-nextjs/issues/80