### PR TITLE
F2P-111 | Player hiscore ranks still incorrect sometimes if EXP is same for multiple players

### DIFF
--- a/src/helpers/hiscores/hiscoresUtils.ts
+++ b/src/helpers/hiscores/hiscoresUtils.ts
@@ -1,5 +1,6 @@
 import { HiscoreDataRow } from '@globalTypes/Database/HiscoreDataRow'
 import { HiscoresSortField } from '@globalTypes/Database/HiscoresSortField'
+import { HiscoreType } from '@globalTypes/Hiscores/HiscoreType'
 
 export const getTotalExp = (hiscoreRow: HiscoreDataRow) =>
   hiscoreRow.attackxp +
@@ -30,4 +31,28 @@ export const isNotBaselineExp = (hiscore: HiscoreDataRow, propName: string) => {
   } else {
     return hiscore[propName as keyof HiscoresSortField] > 0
   }
+}
+
+export const compareHiscores = (hiscoreType: HiscoreType, playerOne: HiscoreDataRow, playerTwo: HiscoreDataRow) => {
+  type HiscoreSortKey = keyof HiscoresSortField
+  let fieldName: HiscoreSortKey
+
+  switch (hiscoreType) {
+    case 'Overall':
+      fieldName = 'skill_total'
+      break
+    default:
+      fieldName = `${hiscoreType.toLowerCase()}xp` as HiscoreSortKey
+      break
+  }
+
+  if (playerOne[fieldName] > playerTwo[fieldName]) {
+    return -1
+  }
+
+  if (playerOne[fieldName] < playerTwo[fieldName]) {
+    return 1
+  }
+
+  return 0
 }

--- a/src/hooks/useHiscores.ts
+++ b/src/hooks/useHiscores.ts
@@ -1,37 +1,12 @@
 import { HiscoreDataRow } from '@globalTypes/Database/HiscoreDataRow'
-import { HiscoresSortField } from '@globalTypes/Database/HiscoresSortField'
 import { HiscoreType } from '@globalTypes/Hiscores/HiscoreType'
-import { isNotBaselineExp } from '@helpers/hiscores/hiscoresUtils'
+import { compareHiscores, isNotBaselineExp } from '@helpers/hiscores/hiscoresUtils'
 import axios from 'axios'
 import { Dispatch, SetStateAction, useEffect, useState } from 'react'
 
 const useHiscores = (hiscoreType: HiscoreType, setIsLoading: Dispatch<SetStateAction<boolean>>) => {
   const [rawHiscores, setRawHiscores] = useState<HiscoreDataRow[] | undefined>(undefined)
   const [hiscores, setHiscores] = useState<HiscoreDataRow[] | undefined>(undefined)
-
-  const compareHiscores = (playerOne: HiscoreDataRow, playerTwo: HiscoreDataRow) => {
-    type HiscoreSortKey = keyof HiscoresSortField
-    let fieldName: HiscoreSortKey
-
-    switch (hiscoreType) {
-      case 'Overall':
-        fieldName = 'skill_total'
-        break
-      default:
-        fieldName = `${hiscoreType.toLowerCase()}xp` as HiscoreSortKey
-        break
-    }
-
-    if (playerOne[fieldName] > playerTwo[fieldName]) {
-      return -1
-    }
-
-    if (playerOne[fieldName] < playerTwo[fieldName]) {
-      return 1
-    }
-
-    return 0
-  }
 
   useEffect(() => {
     setIsLoading(true)
@@ -50,7 +25,7 @@ const useHiscores = (hiscoreType: HiscoreType, setIsLoading: Dispatch<SetStateAc
     const propName = hiscoreType === 'Overall' ? 'skill_total' : `${hiscoreType.toLowerCase()}xp`
     const sortedHiscores = rawHiscores
       ?.filter(hiscoreRow => isNotBaselineExp(hiscoreRow, propName))
-      .sort(compareHiscores)
+      .sort((hiscoreRow1, hiscoreRow2) => compareHiscores(hiscoreType, hiscoreRow1, hiscoreRow2))
 
     setHiscores(sortedHiscores)
     setIsLoading(false)

--- a/src/pages/hiscores/player/[accountName].tsx
+++ b/src/pages/hiscores/player/[accountName].tsx
@@ -7,7 +7,7 @@ import { HiscoreDataRow } from '@globalTypes/Database/HiscoreDataRow'
 import { HiscoresSortField } from '@globalTypes/Database/HiscoresSortField'
 import { HiscoreType } from '@globalTypes/Hiscores/HiscoreType'
 import { PlayerHiscoreRow } from '@globalTypes/Hiscores/PlayerHiscoreRow'
-import { convertExp, getTotalExp, isNotBaselineExp } from '@helpers/hiscores/hiscoresUtils'
+import { compareHiscores, convertExp, getTotalExp, isNotBaselineExp } from '@helpers/hiscores/hiscoresUtils'
 import { Spinner } from '@molecules/Spinner'
 import { PlayerHiscoreTableContainer } from '@styledPages/hiscores.styled'
 import axios from 'axios'
@@ -28,8 +28,8 @@ const PlayerHiscore = () => {
     // Order hiscoresData by hiscoreType descending
     const propName = hiscoreType === 'Overall' ? 'skill_total' : `${hiscoreType.toLowerCase()}xp`
     const sortedHiscoresData = hiscoresData
-      ?.sort((obj1, obj2) => obj2[propName as keyof HiscoresSortField] - obj1[propName as keyof HiscoresSortField])
-      .filter(hiscore => isNotBaselineExp(hiscore, propName))
+      ?.filter(hiscore => isNotBaselineExp(hiscore, propName))
+      .sort((obj1, obj2) => compareHiscores(hiscoreType, obj1, obj2))
 
     // Then get the index of the current player in that sorted list (and if 0-based, add 1), that's the rank.
     const rank = sortedHiscoresData?.findIndex(isMatchingUser)


### PR DESCRIPTION
# What's Changed

- Fixed issue with Player Hiscores where some ranks were incorrect if multiple players had the same experience in a skill, by moving `compareHiscores` function to `hiscoresUtils` and reusing this function for both the main hiscores and player hiscores, and also filtering the hiscores on the player page before sorting