### PR TITLE
F2P-124 | API Security Flaws

### DIFF
--- a/src/pages/api/updateGameAccountPassword/index.ts
+++ b/src/pages/api/updateGameAccountPassword/index.ts
@@ -14,9 +14,9 @@ const handler = async (req: NextApiRequest, res: NextApiResponse<User>) => {
     return
   }
 
-  const query = `UPDATE players SET pass = ? WHERE id = ?`
+  const query = `UPDATE players SET pass = ? WHERE id = ? AND websiteUserId = ?`
 
-  return handleManipulate('game', query, res, [newPassword, accountId])
+  return handleManipulate('game', query, res, [newPassword, accountId, userId])
 }
 
 export default handler

--- a/src/pages/api/updateGameAccountUsername/index.ts
+++ b/src/pages/api/updateGameAccountUsername/index.ts
@@ -14,9 +14,10 @@ const handler = async (req: NextApiRequest, res: NextApiResponse<User>) => {
     return
   }
 
-  const query = `UPDATE players SET former_name = ?, username = ? WHERE id = ?`
+  const query = `UPDATE players SET former_name = ?, username = ? WHERE id = ? AND websiteUserId = ?
+    AND NOT EXISTS (SELECT username FROM players WHERE username = ?) AND former_name = ''`
 
-  return handleManipulate('game', query, res, [currentName, newName, accountId])
+  return handleManipulate('game', query, res, [currentName, newName, accountId, userId, newName])
 }
 
 export default handler

--- a/src/pages/api/updateWebsiteUserEmailAddress/index.ts
+++ b/src/pages/api/updateWebsiteUserEmailAddress/index.ts
@@ -15,9 +15,10 @@ const handler = async (req: NextApiRequest, res: NextApiResponse<User>) => {
     return
   }
 
-  const query = `UPDATE users SET emailAddress = ?, dateModified = ? WHERE id = ?`
+  const query = `UPDATE users SET emailAddress = ?, dateModified = ? WHERE id = ? 
+    AND NOT EXISTS (SELECT emailAddress FROM users WHERE emailAddress = ?)`
 
-  return handleManipulate('website', query, res, [newEmail, now, userId])
+  return handleManipulate('website', query, res, [newEmail, now, userId, newEmail])
 }
 
 export default handler


### PR DESCRIPTION
# What's Changed

- Fixed flaws with `updateGameAccountXXX` APIs by checking that the `websiteUserId` matches the current `userId` - this prevents users from updating accounts that aren't theirs
- Fixed `updateGameAccountUsername` so it does not update the username if the new username already exists (i.e. someone else has it) or if the `former_name` has a value (indicates the user already renamed, so this prevents users from renaming multiple times via the API)
- Fixed a  bug with `updateWebsiteUserEmailAddress` where it did not check if the new email already existed in the DB

