### PR TITLE
F2P-134 | A couple `createPlayerRecord` issues remaining

### DIFF
--- a/src/helpers/api/apiHandler.ts
+++ b/src/helpers/api/apiHandler.ts
@@ -48,10 +48,7 @@ export const handleManipulate = async (
     }
 
     if (response?.affectedRows < 1) {
-      throw new Error(
-        noRowsAffectedErrorMessage ||
-          `No rows affected. Affected Rows: ${response.affectedRows}. Response: ${response}`,
-      )
+      throw new Error(noRowsAffectedErrorMessage || `No rows affected. Response: ${response}`)
     }
 
     // Return a JSON result indicating success

--- a/src/helpers/api/apiHandler.ts
+++ b/src/helpers/api/apiHandler.ts
@@ -37,6 +37,7 @@ export const handleManipulate = async (
   sqlQuery: string,
   res: NextApiResponse<User>,
   sqlParams?: string[] | Record<string, string>,
+  noRowsAffectedErrorMessage?: string,
   returnLastInsertedId?: boolean,
 ): Promise<void> => {
   try {
@@ -47,7 +48,10 @@ export const handleManipulate = async (
     }
 
     if (response?.affectedRows < 1) {
-      throw new Error(`No rows affected. Affected Rows: ${response.affectedRows}. Response: ${response}`)
+      throw new Error(
+        noRowsAffectedErrorMessage ||
+          `No rows affected. Affected Rows: ${response.affectedRows}. Response: ${response}`,
+      )
     }
 
     // Return a JSON result indicating success

--- a/src/helpers/api/apiUtils.ts
+++ b/src/helpers/api/apiUtils.ts
@@ -1,4 +1,5 @@
 import axios from 'axios'
+import { NextApiResponse } from 'next'
 
 /** This type comprises all the possible types of values in body properties. */
 type BodyValueType = string | number | string[] | undefined | boolean | Date
@@ -56,4 +57,11 @@ export const shouldBlockApiCall = async (userId: string, sessionCookie: string |
     })
 
   return returnValue
+}
+
+export const sendBadRequest = (res: NextApiResponse, errorMessage: string) => {
+  res.statusCode = 400
+  res.setHeader('Content-Type', 'application/json')
+  res.end(JSON.stringify(errorMessage))
+  return
 }

--- a/src/helpers/db.ts
+++ b/src/helpers/db.ts
@@ -43,5 +43,5 @@ export const queryDatabase = async <T>(
 }
 
 export const isOkPacket = (o: any): o is OkPacket => {
-  return o && Object.prototype.hasOwnProperty.call(o, 'insertId') && typeof o.insertId === 'number'
+  return o && 'insertId' in o && typeof o.insertId === 'number'
 }

--- a/src/helpers/db.ts
+++ b/src/helpers/db.ts
@@ -43,7 +43,5 @@ export const queryDatabase = async <T>(
 }
 
 export const isOkPacket = (o: any): o is OkPacket => {
-  return (
-    o && Object.prototype.hasOwnProperty.call(o, 'insertId') && typeof o.insertId === 'number' && o.affectedRows > 0
-  )
+  return o && Object.prototype.hasOwnProperty.call(o, 'insertId') && typeof o.insertId === 'number'
 }

--- a/src/pages/account/game-accounts/create/index.tsx
+++ b/src/pages/account/game-accounts/create/index.tsx
@@ -12,7 +12,6 @@ import { UserIsLoggedIn } from '@helpers/users/users'
 import { NotLoggedIn } from '@molecules/NotLoggedIn'
 import { Spinner } from '@molecules/Spinner'
 import { PageHeading } from '@atoms/PageHeading'
-import { BannedText } from 'src/data/BannedText'
 import { sanitizeRunescapePassword } from '@helpers/string/stringUtils'
 import { sendApiRequest } from '@helpers/api/apiUtils'
 import axios from 'axios'
@@ -45,32 +44,6 @@ const CreateGameAccount = () => {
     event.preventDefault()
     setSubmitDisabled(true)
 
-    // Check if name is empty
-    if (accountName.replace(/_/g, ' ').trim().length < 1) {
-      setSubmitDisabled(false)
-      setValidationError('You cannot have an account name with only spaces.')
-      return
-    }
-
-    // Only allow game account names with letters, numbers, underscores and spaces.
-    const validUsernameMatches = accountName.match(/^[a-zA-Z0-9_ ]+$/g)
-    if (!validUsernameMatches || !validUsernameMatches?.[0]) {
-      setSubmitDisabled(false)
-      setValidationError('Your account name can only have letters, numbers, underscores and spaces.')
-      return
-    }
-
-    // Look for any bad or undesired words in names
-    if (BannedText.some(text => accountName.toLowerCase().includes(text))) {
-      setSubmitDisabled(false)
-      setValidationError('Your account name has been determined to be offensive or misleading. Please try another one.')
-      return
-    }
-
-    // Replace underscores with spaces in username. RSC+ signup does this.
-    // Underscores are translated as spaces on login, but the account name cannot have underscores in the database.
-    const sanitizedAccountName = accountName.replace(/_/g, ' ').trim()
-
     // Confirm passwords match
     if (password != confirmPassword) {
       setSubmitDisabled(false)
@@ -88,7 +61,7 @@ const CreateGameAccount = () => {
       // Create account
       sendApiRequest('POST', '/api/createPlayerRecord', {
         userId: user.id,
-        accountName: sanitizedAccountName,
+        accountName,
         password: hashedPassword,
         websiteAccountId: user?.id,
         userIp: response?.data?.ip,

--- a/src/pages/account/game-accounts/create/index.tsx
+++ b/src/pages/account/game-accounts/create/index.tsx
@@ -63,7 +63,6 @@ const CreateGameAccount = () => {
         userId: user.id,
         accountName,
         password: hashedPassword,
-        websiteAccountId: user?.id,
         userIp: response?.data?.ip,
       })
         .then(response => {

--- a/src/pages/api/createPlayerRecord/index.ts
+++ b/src/pages/api/createPlayerRecord/index.ts
@@ -5,7 +5,7 @@ import { sendBadRequest, shouldBlockApiCall } from '@helpers/api/apiUtils'
 import { BannedText } from 'src/data/BannedText'
 
 const handler = async (req: NextApiRequest, res: NextApiResponse<User>) => {
-  const { userId, accountName, password, websiteAccountId, userIp } = req.body
+  const { userId, accountName, password, userIp } = req.body
   const creationDateMillis = Math.round(new Date().getTime() / 1000)
   const sessionCookie = req.cookies?.['neat-f2p-session']
 
@@ -26,11 +26,6 @@ const handler = async (req: NextApiRequest, res: NextApiResponse<User>) => {
   // Check if name is correct length
   if (cleanedAccountName.length < 1 || cleanedAccountName.length > 12) {
     return sendBadRequest(res, 'Account names must be 1-12 characters in length.')
-  }
-
-  // Check that user IDs match so the user cannot create game accounts for others
-  if (userId !== websiteAccountId) {
-    return sendBadRequest(res, 'You cannot associate game accounts with website accounts that are not your own.')
   }
 
   // Only allow game account names with letters, numbers, underscores and spaces.
@@ -55,7 +50,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse<User>) => {
     'game',
     query,
     res,
-    [cleanedAccountName, password, creationDateMillis, userIp, websiteAccountId, cleanedAccountName],
+    [cleanedAccountName, password, creationDateMillis, userIp, userId, cleanedAccountName],
     'The account name you entered is currently taken. Please try another one.',
     true,
   )

--- a/src/pages/api/createPlayerRecord/index.ts
+++ b/src/pages/api/createPlayerRecord/index.ts
@@ -1,7 +1,8 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 import { User } from '@globalTypes/User'
 import { handleManipulate } from '@helpers/api/apiHandler'
-import { shouldBlockApiCall } from '@helpers/api/apiUtils'
+import { sendBadRequest, shouldBlockApiCall } from '@helpers/api/apiUtils'
+import { BannedText } from 'src/data/BannedText'
 
 const handler = async (req: NextApiRequest, res: NextApiResponse<User>) => {
   const { userId, accountName, password, websiteAccountId, userIp } = req.body
@@ -11,8 +12,38 @@ const handler = async (req: NextApiRequest, res: NextApiResponse<User>) => {
   if (await shouldBlockApiCall(userId, sessionCookie)) {
     res.statusCode = 403
     res.setHeader('Content-Type', 'application/json')
-    res.end(JSON.stringify(`Forbidden`))
+    res.end(JSON.stringify('Forbidden'))
     return
+  }
+
+  // Input validation
+  const validUsernameMatches = accountName.match(/^[a-zA-Z0-9_ ]+$/g)
+
+  // Replace underscores with spaces in username. RSC+ signup does this.
+  // Underscores are translated as spaces on login, but the account name cannot have underscores in the database.
+  const cleanedAccountName = accountName.replace(/_/g, ' ').trim()
+
+  // Check if name is correct length
+  if (cleanedAccountName.length < 1 || cleanedAccountName.length > 12) {
+    return sendBadRequest(res, 'Account names must be 1-12 characters in length.')
+  }
+
+  // Check that user IDs match so the user cannot create game accounts for others
+  if (userId !== websiteAccountId) {
+    return sendBadRequest(res, 'You cannot associate game accounts with website accounts that are not your own.')
+  }
+
+  // Only allow game account names with letters, numbers, underscores and spaces.
+  if (!validUsernameMatches || !validUsernameMatches?.[0]) {
+    return sendBadRequest(res, 'Your account name can only have letters, numbers, underscores and spaces.')
+  }
+
+  // Look for any bad or undesired words in names
+  if (BannedText.some(text => accountName.toLowerCase().includes(text))) {
+    return sendBadRequest(
+      res,
+      'Your account name has been determined to be offensive or misleading. Please try another one.',
+    )
   }
 
   const query = `INSERT INTO players (username, pass, creation_date, creation_ip, websiteUserId)
@@ -24,7 +55,8 @@ const handler = async (req: NextApiRequest, res: NextApiResponse<User>) => {
     'game',
     query,
     res,
-    [accountName, password, creationDateMillis, userIp, websiteAccountId, accountName],
+    [cleanedAccountName, password, creationDateMillis, userIp, websiteAccountId, cleanedAccountName],
+    'The account name you entered is currently taken. Please try another one.',
     true,
   )
 }


### PR DESCRIPTION
# What's Changed

- Prevent `createPlayerRecord` from adding new game accounts under different website users
- Moved input validation to API so Postman/cURL requests are validated for new accounts
- Fixed rows affected error reporting in `handleManipulate`
- Created `sendBadRequest` helper