### PR TITLE
F2P-136 | APIs fail with 403 sometimes

### DIFF
--- a/src/pages/account/create/index.tsx
+++ b/src/pages/account/create/index.tsx
@@ -24,6 +24,7 @@ const CreateAccountPage = () => {
   const [password, setPassword] = useState('')
   const [confirmPassword, setConfirmPassword] = useState('')
   const [validationError, setValidationError] = useState('')
+  const [submitDisabled, setSubmitDisabled] = useState(false)
   const user = useAuthentication(setLoading)
 
   const handleEmailChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -48,9 +49,11 @@ const CreateAccountPage = () => {
 
   const handleAccountCreation = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
+    setSubmitDisabled(true)
 
     // Confirm passwords match
     if (password != confirmPassword) {
+      setSubmitDisabled(false)
       setValidationError('Passwords do not match.')
       return
     }
@@ -72,6 +75,7 @@ const CreateAccountPage = () => {
       .then(response => {
         if (response?.status !== 200) {
           // Display error to user (usually due to a taken email or username).
+          setSubmitDisabled(false)
           setValidationError(response?.data)
         } else if (typeof response?.data === 'string') {
           const user: User = {
@@ -87,6 +91,7 @@ const CreateAccountPage = () => {
           sendApiRequest('POST', '/api/ironLogin', { ...user })
             .then(response => {
               if (response?.status !== 200) {
+                setSubmitDisabled(false)
                 setValidationError(
                   `An error occurred logging you into the new account: HTTP ${response?.status}: ${response?.statusText}.`,
                 )
@@ -100,16 +105,19 @@ const CreateAccountPage = () => {
                     redirectTo('/account/create/success')
                   })
                   .catch((error: { response: { data: string } }) => {
+                    setSubmitDisabled(false)
                     setValidationError(`Couldn't update user session: ${error?.response?.data}`)
                   })
               }
             })
             .catch((error: { response: { data: string } }) => {
+              setSubmitDisabled(false)
               setValidationError(`An error occurred logging you into the new account: ${error?.response?.data}`)
             })
         }
       })
       .catch((error: { response: { data: string } }) => {
+        setSubmitDisabled(false)
         setValidationError(error.response.data)
       })
   }
@@ -172,7 +180,7 @@ const CreateAccountPage = () => {
           onChange={handleConfirmPasswordChange}
         />
         <FieldValidationMessage>{validationError}</FieldValidationMessage>
-        <FormButton variant='contained' type='submit' disabled={!!validationError}>
+        <FormButton variant='contained' type='submit' disabled={submitDisabled}>
           Submit
         </FormButton>
       </Form>

--- a/src/pages/account/login/index.tsx
+++ b/src/pages/account/login/index.tsx
@@ -40,6 +40,7 @@ const AccountLoginPage = () => {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [validationError, setValidationError] = useState('')
+  const [buttonDisabled, setButtonDisabled] = useState(false)
   const user = useAuthentication(setLoading)
   const userIsLoggedIn = UserIsLoggedIn(user)
 
@@ -61,6 +62,7 @@ const AccountLoginPage = () => {
 
   const handleLogin = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
+    setButtonDisabled(true)
 
     sendApiRequest('GET', `/api/getUser?email=${email}`)
       .then(async response => {
@@ -68,6 +70,7 @@ const AccountLoginPage = () => {
 
         // First thing would be to confirm the user exists.
         if (!UserExists(result)) {
+          setButtonDisabled(false)
           setValidationError('Email does not exist.')
           return
         }
@@ -80,11 +83,13 @@ const AccountLoginPage = () => {
         try {
           currentPasswordHashed = bcrypt.hashSync(password, passwordSalt)
         } catch (e) {
+          setButtonDisabled(false)
           setValidationError(`An error occurred. ${e}. Please notify the admin.`)
           return
         }
 
         if (hashedPassword !== currentPasswordHashed) {
+          setButtonDisabled(false)
           setValidationError('Password is incorrect.')
           return
         }
@@ -95,6 +100,7 @@ const AccountLoginPage = () => {
         sendApiRequest('POST', '/api/ironLogin', { ...user })
           .then(response => {
             if (response?.status !== 200) {
+              setButtonDisabled(false)
               setValidationError('An error occurred logging you in.')
             } else {
               // We will now log IPs for website account logins, for security.
@@ -109,12 +115,14 @@ const AccountLoginPage = () => {
                     redirectTo('/')
                   })
                   .catch((error: { response: { data: string } }) => {
+                    setButtonDisabled(false)
                     setValidationError(`Couldn't update user session: ${error?.response?.data}`)
                   })
               })
             }
           })
           .catch((error: { response: { data: string } }) => {
+            setButtonDisabled(false)
             setValidationError(`An error occurred logging you in: ${error?.response?.data}`)
           })
       })
@@ -141,7 +149,7 @@ const AccountLoginPage = () => {
         <ForgotPasswordBlock variant='body' topMargin={20} textAlign='left'>
           <ForgotPasswordLink href='/account/login/forgot-password'>Forgot Password?</ForgotPasswordLink>
         </ForgotPasswordBlock>
-        <FormButton variant='contained' type='submit'>
+        <FormButton variant='contained' type='submit' disabled={buttonDisabled}>
           Log In
         </FormButton>
       </Form>


### PR DESCRIPTION
# What's Changed

- Disabled Log In / Submit buttons after click on Login and Create pages for website accounts so the APIs tied to these buttons are not called multiple times due to the button being clicked more than once

# Notes

Not actually 100% sure if this will fix the issue. The issue isn't really reproducible locally with this fix though.