### PR TITLE
F2P-136 | Spinning 403 issue solve

### DIFF
--- a/src/components/organisms/GameAccountsTable/GameAccountsTable.styled.ts
+++ b/src/components/organisms/GameAccountsTable/GameAccountsTable.styled.ts
@@ -24,6 +24,17 @@ export const AccountTable = styled(Table, {
   `,
 )
 
+export const DesktopSpinner = styled('div')(
+  ({ theme }) => css`
+    display: none;
+
+    ${theme.breakpoints.up('tablet')} {
+      display: block;
+      margin-top: 20px;
+    }
+  `,
+)
+
 export const TabletDesktopBodyText = styled(BodyText)(
   ({ theme }) => css`
     display: none;

--- a/src/components/organisms/GameAccountsTable/GameAccountsTable.tsx
+++ b/src/components/organisms/GameAccountsTable/GameAccountsTable.tsx
@@ -1,7 +1,7 @@
 import { Spinner } from '@molecules/Spinner'
 import { TableBody, TableHead, TableRow, Paper } from '@mui/material'
 import { useEffect, useState } from 'react'
-import { AccountTable, AccountTableContainer, TabletDesktopBodyText } from './GameAccountsTable.styled'
+import { AccountTable, AccountTableContainer, DesktopSpinner, TabletDesktopBodyText } from './GameAccountsTable.styled'
 import { GameAccountRow } from '@atoms/GameAccountRow'
 import { GameAccountsTableProps } from './GameAccountsTable.types'
 import { RenameAccountModal } from '@organisms/RenameAccountModal'
@@ -28,7 +28,11 @@ const GameAccountsTable = (props: GameAccountsTableProps) => {
   }, [accounts])
 
   if (isLoading) {
-    return <Spinner />
+    return (
+      <DesktopSpinner>
+        <Spinner />
+      </DesktopSpinner>
+    )
   } else if (process.env.NEXT_PUBLIC_GAME_ACCOUNTS_DISABLE_CREATION === 'true') {
     return null
   } else if (accounts && accounts.length < 1) {

--- a/src/components/organisms/GameAccountsTableMobile/GameAccountsTableMobile.styled.ts
+++ b/src/components/organisms/GameAccountsTableMobile/GameAccountsTableMobile.styled.ts
@@ -27,7 +27,7 @@ export const MobileSpinner = styled('div')(
   ({ theme }) => css`
     margin-top: 20px;
 
-    ${theme.breakpoints.up('mobile')} {
+    ${theme.breakpoints.up('tablet')} {
       display: none;
     }
   `,

--- a/src/components/organisms/GameAccountsTableMobile/GameAccountsTableMobile.styled.ts
+++ b/src/components/organisms/GameAccountsTableMobile/GameAccountsTableMobile.styled.ts
@@ -23,6 +23,16 @@ export const AccountTable = styled(Table, {
   `,
 )
 
+export const MobileSpinner = styled('div')(
+  ({ theme }) => css`
+    margin-top: 20px;
+
+    ${theme.breakpoints.up('mobile')} {
+      display: none;
+    }
+  `,
+)
+
 export const MobileBodyText = styled(BodyText)(
   ({ theme }) => css`
     ${theme.breakpoints.up('tablet')} {

--- a/src/components/organisms/GameAccountsTableMobile/GameAccountsTableMobile.tsx
+++ b/src/components/organisms/GameAccountsTableMobile/GameAccountsTableMobile.tsx
@@ -2,7 +2,7 @@ import { PlayerDataRow } from '@globalTypes/Database/PlayerDataRow'
 import { Spinner } from '@molecules/Spinner'
 import { TableBody, Paper, Button } from '@mui/material'
 import { useEffect, useState } from 'react'
-import { AccountTable, AccountTableContainer, MobileBodyText } from './GameAccountsTableMobile.styled'
+import { AccountTable, AccountTableContainer, MobileBodyText, MobileSpinner } from './GameAccountsTableMobile.styled'
 import { GameAccountsTableProps } from '@organisms/GameAccountsTable/GameAccountsTable.types'
 import { RenameAccountModal } from '@organisms/RenameAccountModal'
 import { PasswordModal } from '@organisms/PasswordModal'
@@ -38,7 +38,11 @@ const GameAccountsTableMobile = (props: GameAccountsTableProps) => {
   }
 
   if (isLoading) {
-    return <Spinner />
+    return (
+      <MobileSpinner>
+        <Spinner />
+      </MobileSpinner>
+    )
   } else if (accounts && accounts.length < 1) {
     return (
       <MobileBodyText variant='body'>You don&apos;t have any accounts right now. Why not create one?</MobileBodyText>

--- a/src/components/organisms/PasswordModal/PasswordModal.tsx
+++ b/src/components/organisms/PasswordModal/PasswordModal.tsx
@@ -4,7 +4,7 @@ import { Field } from '@atoms/Field'
 import { Modal } from '@molecules/Modal'
 import { hashPassword } from '@helpers/password'
 import { sanitizeRunescapePassword } from '@helpers/string/stringUtils'
-import { sendApiRequest } from '@helpers/api/apiUtils'
+import { handleForbiddenRedirect, sendApiRequest } from '@helpers/api/apiUtils'
 import { User } from '@globalTypes/User'
 
 type PasswordModalProps = {
@@ -60,17 +60,21 @@ const PasswordModal = (props: PasswordModalProps) => {
       userId: user?.id,
       accountId: account.id,
       newPassword: hashedPassword,
-    }).then(response => {
-      if (typeof response?.data === 'number') {
-        setSuccessMessage('Your password has been updated successfully! This window will now close...')
-        setTimeout(() => {
-          handleClose()
-        }, 3000)
-      } else {
-        const errorMessage = `Non-number response type in PasswordModal: ${response?.data}`
-        console.log(errorMessage)
-      }
     })
+      .then(response => {
+        if (typeof response?.data === 'number') {
+          setSuccessMessage('Your password has been updated successfully! This window will now close...')
+          setTimeout(() => {
+            handleClose()
+          }, 3000)
+        } else {
+          const errorMessage = `Non-number response type in PasswordModal: ${response?.data}`
+          console.log(errorMessage)
+        }
+      })
+      .catch((error: string) => {
+        handleForbiddenRedirect(error)
+      })
   }
 
   if (!open) return null

--- a/src/components/organisms/RenameAccountModal/RenameAccountModal.tsx
+++ b/src/components/organisms/RenameAccountModal/RenameAccountModal.tsx
@@ -3,7 +3,7 @@ import { PlayerDataRow } from '@globalTypes/Database/PlayerDataRow'
 import { Warning } from './RenameAccountModal.styled'
 import { Modal } from '@molecules/Modal'
 import { Field } from '@atoms/Field'
-import { sendApiRequest } from '@helpers/api/apiUtils'
+import { handleForbiddenRedirect, sendApiRequest } from '@helpers/api/apiUtils'
 import { User } from '@globalTypes/User'
 
 type RenameAccountModalProps = {
@@ -56,19 +56,23 @@ const RenameAccountModal = (props: RenameAccountModalProps) => {
       accountId: account.id,
       currentName: account.username,
       newName: newAccountName,
-    }).then(response => {
-      if (typeof response?.data === 'number') {
-        setSuccessMessage('Your account has been renamed successfully! This page will now refresh.')
-        setTimeout(() => {
-          if (typeof window !== 'undefined') {
-            location.reload()
-          }
-        }, 3000)
-      } else {
-        const errorMessage = `Non-number response type in RenameAccountModal: ${response?.data}`
-        console.log(errorMessage)
-      }
     })
+      .then(response => {
+        if (typeof response?.data === 'number') {
+          setSuccessMessage('Your account has been renamed successfully! This page will now refresh.')
+          setTimeout(() => {
+            if (typeof window !== 'undefined') {
+              location.reload()
+            }
+          }, 3000)
+        } else {
+          const errorMessage = `Non-number response type in RenameAccountModal: ${response?.data}`
+          console.log(errorMessage)
+        }
+      })
+      .catch((error: string) => {
+        handleForbiddenRedirect(error)
+      })
   }
 
   if (!open) return null

--- a/src/helpers/api/apiUtils.ts
+++ b/src/helpers/api/apiUtils.ts
@@ -1,3 +1,4 @@
+import { redirectTo } from '@helpers/window'
 import axios from 'axios'
 import { NextApiResponse } from 'next'
 
@@ -64,4 +65,19 @@ export const sendBadRequest = (res: NextApiResponse, errorMessage: string) => {
   res.setHeader('Content-Type', 'application/json')
   res.end(JSON.stringify(errorMessage))
   return
+}
+
+export const handleForbiddenRedirect = (error: string) => {
+  // If the error is an HTTP 403, it means the user's session cookie value
+  // no longer matches the one that was saved when they last logged in.
+  // Log the user out and redirect to the Session Expired page.
+  if (error.toString().includes('403') || error.toString().toLowerCase().includes('forbidden')) {
+    sendApiRequest('GET', '/api/ironLogout')
+      .then(() => {
+        redirectTo('/account/session-expired')
+      })
+      .catch((error: string) => {
+        console.log('An error occurred on logout (expired session): ', error)
+      })
+  }
 }

--- a/src/hooks/useGameAccounts.ts
+++ b/src/hooks/useGameAccounts.ts
@@ -1,5 +1,5 @@
 import { PlayerDataRow } from '@globalTypes/Database/PlayerDataRow'
-import { sendApiRequest } from '@helpers/api/apiUtils'
+import { handleForbiddenRedirect, sendApiRequest } from '@helpers/api/apiUtils'
 import { useEffect, useState } from 'react'
 
 const useGameAccounts = (userId: string | undefined) => {
@@ -11,7 +11,10 @@ const useGameAccounts = (userId: string | undefined) => {
         .then(response => {
           setAccounts(response.data)
         })
-        .catch((error: string) => console.log(error))
+        .catch((error: string) => {
+          console.log(error)
+          handleForbiddenRedirect(error)
+        })
     }
 
     if (accounts === undefined) {

--- a/src/pages/account/change-email/[id].tsx
+++ b/src/pages/account/change-email/[id].tsx
@@ -1,7 +1,7 @@
 import { BodyText } from '@atoms/BodyText'
 import { ContentBlock } from '@atoms/ContentBlock'
 import { PageHeading } from '@atoms/PageHeading'
-import { sendApiRequest } from '@helpers/api/apiUtils'
+import { handleForbiddenRedirect, sendApiRequest } from '@helpers/api/apiUtils'
 import useAuthentication from '@hooks/useAuthentication'
 import { Spinner } from '@molecules/Spinner'
 import Link from 'next/link'
@@ -21,9 +21,13 @@ const ChangeEmailByIdPage = () => {
     sendApiRequest('POST', '/api/updateWebsiteUserEmailAddress', {
       userId: accountId,
       newEmail,
-    }).then(() => {
-      setIsLoading(false)
     })
+      .then(() => {
+        setIsLoading(false)
+      })
+      .catch((error: string) => {
+        handleForbiddenRedirect(error)
+      })
   }, [accountId, newEmail, user.id])
 
   if (isLoading) {

--- a/src/pages/account/change-password/index.tsx
+++ b/src/pages/account/change-password/index.tsx
@@ -10,7 +10,7 @@ import { Form } from '@atoms/Form'
 import { redirectTo } from '@helpers/window'
 import { FieldValidationMessage } from '@atoms/FieldValidationMessage'
 import { hashPassword } from '@helpers/password'
-import { sendApiRequest } from '@helpers/api/apiUtils'
+import { handleForbiddenRedirect, sendApiRequest } from '@helpers/api/apiUtils'
 
 const ChangePasswordPage = () => {
   const [isLoading, setIsLoading] = useState(true)
@@ -49,16 +49,20 @@ const ChangePasswordPage = () => {
       userId: user.id,
       newPassword: hashedPassword,
       newPasswordSalt: passwordSalt,
-    }).then(response => {
-      if (typeof response?.data === 'number') {
-        // Reset was successful - redirect to success page
-        redirectTo('/account/change-password/success')
-      } else {
-        const errorMessage = `Non-number response type in change-password: ${response?.data}`
-        console.log(errorMessage)
-        setFormValidationError(`Something went wrong. Please try again later. Error: ${errorMessage}`)
-      }
     })
+      .then(response => {
+        if (typeof response?.data === 'number') {
+          // Reset was successful - redirect to success page
+          redirectTo('/account/change-password/success')
+        } else {
+          const errorMessage = `Non-number response type in change-password: ${response?.data}`
+          console.log(errorMessage)
+          setFormValidationError(`Something went wrong. Please try again later. Error: ${errorMessage}`)
+        }
+      })
+      .catch((error: string) => {
+        handleForbiddenRedirect(error)
+      })
   }
 
   if (isLoading) {

--- a/src/pages/account/change-username/index.tsx
+++ b/src/pages/account/change-username/index.tsx
@@ -10,7 +10,7 @@ import { Form } from '@atoms/Form'
 import { redirectTo } from '@helpers/window'
 import { FieldValidationMessage } from '@atoms/FieldValidationMessage'
 import { BannedText } from 'src/data/BannedText'
-import { sendApiRequest } from '@helpers/api/apiUtils'
+import { handleForbiddenRedirect, sendApiRequest } from '@helpers/api/apiUtils'
 import { UserIsLoggedIn } from '@helpers/users/users'
 import { NotLoggedIn } from '@molecules/NotLoggedIn'
 
@@ -62,9 +62,13 @@ const ChangeUsernamePage = () => {
     sendApiRequest('POST', '/api/updateWebsiteUserUsername', {
       userId: user.id,
       newUsername,
-    }).then(() => {
-      redirectTo('/account/change-username/success')
     })
+      .then(() => {
+        redirectTo('/account/change-username/success')
+      })
+      .catch((error: string) => {
+        handleForbiddenRedirect(error)
+      })
   }
 
   if (isLoading) {

--- a/src/pages/account/game-accounts/create/index.tsx
+++ b/src/pages/account/game-accounts/create/index.tsx
@@ -82,6 +82,7 @@ const CreateGameAccount = () => {
               .catch((error: { response: { data: string } }) => {
                 setSubmitDisabled(false)
                 setValidationError(error.response.data)
+                handleForbiddenRedirect(error.response.data)
               })
           }
         })

--- a/src/pages/account/game-accounts/create/index.tsx
+++ b/src/pages/account/game-accounts/create/index.tsx
@@ -13,7 +13,7 @@ import { NotLoggedIn } from '@molecules/NotLoggedIn'
 import { Spinner } from '@molecules/Spinner'
 import { PageHeading } from '@atoms/PageHeading'
 import { sanitizeRunescapePassword } from '@helpers/string/stringUtils'
-import { sendApiRequest } from '@helpers/api/apiUtils'
+import { handleForbiddenRedirect, sendApiRequest } from '@helpers/api/apiUtils'
 import axios from 'axios'
 
 const CreateGameAccount = () => {
@@ -88,6 +88,7 @@ const CreateGameAccount = () => {
         .catch((error: { response: { data: string } }) => {
           setSubmitDisabled(false)
           setValidationError(error.response.data)
+          handleForbiddenRedirect(error.response.data)
         })
     })
   }

--- a/src/pages/account/session-expired/index.tsx
+++ b/src/pages/account/session-expired/index.tsx
@@ -1,0 +1,16 @@
+import { ContentBlock } from '@atoms/ContentBlock'
+import { BodyText } from '@atoms/BodyText'
+import { InlineLink } from '@atoms/InlineLink'
+import { PageHeading } from '@atoms/PageHeading'
+
+const SessionExpiredPage = () => (
+  <ContentBlock>
+    <PageHeading>Session Expired</PageHeading>
+    <BodyText variant='body' textAlign='center'>
+      Your session has expired. Perhaps you logged in on a different computer or browser? Please{' '}
+      <InlineLink href='/account/login'>login</InlineLink> again.
+    </BodyText>
+  </ContentBlock>
+)
+
+export default SessionExpiredPage

--- a/src/pages/account/session-expired/index.tsx
+++ b/src/pages/account/session-expired/index.tsx
@@ -7,8 +7,10 @@ const SessionExpiredPage = () => (
   <ContentBlock>
     <PageHeading>Session Expired</PageHeading>
     <BodyText variant='body' textAlign='center'>
-      Your session has expired. Perhaps you logged in on a different computer or browser? Please{' '}
-      <InlineLink href='/account/login'>login</InlineLink> again.
+      Your session has expired. Perhaps you logged in on a different computer or browser?
+    </BodyText>
+    <BodyText variant='body' textAlign='center'>
+      Please<InlineLink href='/account/login'>login</InlineLink> again.
     </BodyText>
   </ContentBlock>
 )

--- a/src/pages/admin/newsPostForm/index.tsx
+++ b/src/pages/admin/newsPostForm/index.tsx
@@ -27,7 +27,7 @@ import { NewsPostTitle } from '@organisms/NewsPostListItem/NewsPostListItem.styl
 import { Field } from '@atoms/Field'
 import CloudUploadIcon from '@mui/icons-material/CloudUpload'
 import { ContentBlock } from '@atoms/ContentBlock'
-import { sendApiRequest } from '@helpers/api/apiUtils'
+import { handleForbiddenRedirect, sendApiRequest } from '@helpers/api/apiUtils'
 
 const NewsPostForm = () => {
   const [loading, setLoading] = useState(true)
@@ -109,6 +109,7 @@ const NewsPostForm = () => {
           answer: error.response.data,
           code: 'red',
         })
+        handleForbiddenRedirect(error.response.data)
       })
   }
 

--- a/src/pages/api/createPlayerSkillRecords/index.ts
+++ b/src/pages/api/createPlayerSkillRecords/index.ts
@@ -10,7 +10,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse<User>) => {
   if (await shouldBlockApiCall(userId, sessionCookie)) {
     res.statusCode = 403
     res.setHeader('Content-Type', 'application/json')
-    res.end(JSON.stringify(`Forbidden`))
+    res.end(JSON.stringify('Forbidden'))
     return
   }
 

--- a/src/pages/api/getGameAccountsForUser/index.ts
+++ b/src/pages/api/getGameAccountsForUser/index.ts
@@ -22,7 +22,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse<Props>) => {
   if (await shouldBlockApiCall(userId, sessionCookie)) {
     res.statusCode = 403
     res.setHeader('Content-Type', 'application/json')
-    res.end(JSON.stringify(`Forbidden`))
+    res.end(JSON.stringify('Forbidden'))
     return
   }
 

--- a/src/pages/api/submitNewsPost/index.ts
+++ b/src/pages/api/submitNewsPost/index.ts
@@ -12,7 +12,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse<NewsPost>) => {
   if (await shouldBlockApiCall(userId, sessionCookie)) {
     res.statusCode = 403
     res.setHeader('Content-Type', 'application/json')
-    res.end(JSON.stringify(`Forbidden`))
+    res.end(JSON.stringify('Forbidden'))
     return
   }
 

--- a/src/pages/api/updateGameAccountPassword/index.ts
+++ b/src/pages/api/updateGameAccountPassword/index.ts
@@ -10,7 +10,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse<User>) => {
   if (await shouldBlockApiCall(userId, sessionCookie)) {
     res.statusCode = 403
     res.setHeader('Content-Type', 'application/json')
-    res.end(JSON.stringify(`Forbidden`))
+    res.end(JSON.stringify('Forbidden'))
     return
   }
 

--- a/src/pages/api/updateGameAccountUsername/index.ts
+++ b/src/pages/api/updateGameAccountUsername/index.ts
@@ -10,7 +10,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse<User>) => {
   if (await shouldBlockApiCall(userId, sessionCookie)) {
     res.statusCode = 403
     res.setHeader('Content-Type', 'application/json')
-    res.end(JSON.stringify(`Forbidden`))
+    res.end(JSON.stringify('Forbidden'))
     return
   }
 

--- a/src/pages/api/updateWebsiteUserEmailAddress/index.ts
+++ b/src/pages/api/updateWebsiteUserEmailAddress/index.ts
@@ -11,7 +11,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse<User>) => {
   if (await shouldBlockApiCall(userId, sessionCookie)) {
     res.statusCode = 403
     res.setHeader('Content-Type', 'application/json')
-    res.end(JSON.stringify(`Forbidden`))
+    res.end(JSON.stringify('Forbidden'))
     return
   }
 

--- a/src/pages/api/updateWebsiteUserPassword/index.ts
+++ b/src/pages/api/updateWebsiteUserPassword/index.ts
@@ -11,7 +11,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse<User>) => {
   if (await shouldBlockApiCall(userId, sessionCookie)) {
     res.statusCode = 403
     res.setHeader('Content-Type', 'application/json')
-    res.end(JSON.stringify(`Forbidden`))
+    res.end(JSON.stringify('Forbidden'))
     return
   }
 

--- a/src/pages/api/updateWebsiteUserUsername/index.ts
+++ b/src/pages/api/updateWebsiteUserUsername/index.ts
@@ -11,7 +11,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse<User>) => {
   if (await shouldBlockApiCall(userId, sessionCookie)) {
     res.statusCode = 403
     res.setHeader('Content-Type', 'application/json')
-    res.end(JSON.stringify(`Forbidden`))
+    res.end(JSON.stringify('Forbidden'))
     return
   }
 


### PR DESCRIPTION
# What's Changed

- Added Session Expired page and functionality to redirect to this page when a 403 is encountered and the user is stuck on the page
- Fixed duplicate loading spinners on the game accounts page

# Notes

This isn't a fix for the 403 error completely, because I realized it's not possible to do so. This 403 issue occurs when you log into your account in a different browser or computer, or even a different website (i.e. you develop locally like me). So a 403 is sort of an _expected_ scenario because you logged in elsewhere and your session cookie is no longer valid.