### PR TITLE
F2P-147 | Remove unused `pass` and `salt` fields

### DIFF
--- a/src/globalTypes/Database/PlayerDataRow.ts
+++ b/src/globalTypes/Database/PlayerDataRow.ts
@@ -3,8 +3,6 @@ export interface PlayerDataRow {
   /** Game account name */
   username: string
   former_name: string
-  pass: string
-  salt: string
   combat: number
   creation_date: number
   login_date: number

--- a/src/pages/api/getGameAccountsForUser/index.ts
+++ b/src/pages/api/getGameAccountsForUser/index.ts
@@ -26,7 +26,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse<Props>) => {
     return
   }
 
-  const query = `SELECT id, username, former_name, pass, salt, combat, creation_date, login_date, banned
+  const query = `SELECT id, username, former_name, combat, creation_date, login_date, banned
     FROM players
     WHERE websiteUserId = ?`
 


### PR DESCRIPTION
# What's Changed

- Removed pass and salt columns from `getGameAccountsForUser` query as the website was doing nothing with them

# How Has This Been Tested?

Confirmed password update feature still functions correctly and that the game accounts page still works normally.