### PR TITLE
F2P-137 | What can we do to protect submitNewsPost calls?

### DIFF
--- a/src/helpers/api/apiUtils.ts
+++ b/src/helpers/api/apiUtils.ts
@@ -30,6 +30,8 @@ export const sendApiRequest = (
   return axios.post(endpointUrl, body)
 }
 
+/** Checks if the `sessionCookie` value provided matches a `session` column value in the database
+ * for the `userId` provided. If not, the API call is blocked (`true` is returned). */
 export const shouldBlockApiCall = async (userId: string, sessionCookie: string | undefined) => {
   let returnValue = false
 

--- a/src/pages/api/submitNewsPost/index.ts
+++ b/src/pages/api/submitNewsPost/index.ts
@@ -17,21 +17,41 @@ const handler = async (req: NextApiRequest, res: NextApiResponse<NewsPost>) => {
   }
 
   try {
-    const insertImageQuery = `INSERT INTO images (image, alt) VALUES (?, ?)`
-    const insertImageResponse: OkPacket | ErrorResult = await queryDatabase('website', insertImageQuery, [image, alt])
+    const insertImageQuery = `INSERT INTO images (image, alt) SELECT ?, ? FROM images WHERE (SELECT COUNT(*) FROM users WHERE id = ? AND isAdmin = 1) > 0 LIMIT 1`
+    const insertImageResponse: OkPacket | ErrorResult = await queryDatabase('website', insertImageQuery, [
+      image,
+      alt,
+      userId,
+    ])
+
+    if (!isOkPacket(insertImageResponse)) {
+      throw new Error(insertImageResponse?.error?.toString())
+    }
+
+    if (insertImageResponse?.affectedRows < 1) {
+      // Probably the user is not an admin...
+      throw new Error('Unauthorized')
+    }
+
     const insertedImageId = isOkPacket(insertImageResponse) && insertImageResponse?.insertId
 
     // Next, build the insertNewsPost command and execute, then return results.
-    const insertNewsPostQuery = `INSERT INTO newsPosts (image, title, datePosted, body) VALUES (?, ?, ?, ?)`
+    const insertNewsPostQuery = `INSERT INTO newsPosts (image, title, datePosted, body) SELECT ?, ?, ?, ? FROM newsPosts WHERE (SELECT COUNT(*) FROM users WHERE id = ? AND isAdmin = 1) > 0 LIMIT 1`
     const insertNewsPostResponse: OkPacket | ErrorResult = await queryDatabase('website', insertNewsPostQuery, [
       insertedImageId,
       title,
       datePosted,
       body,
+      userId,
     ])
 
     if (!isOkPacket(insertNewsPostResponse)) {
       throw new Error(insertNewsPostResponse?.error?.toString())
+    }
+
+    if (insertNewsPostResponse?.affectedRows < 1) {
+      // Probably the user is not an admin...
+      throw new Error('Unauthorized')
     }
 
     const insertedNewsPostId = insertNewsPostResponse?.insertId


### PR DESCRIPTION
# What's Changed

- Added code to prevent any authenticated user from submitting news posts by checking if they are an admin in the query
- Added function comment to `shouldBlockApiCall` explaining what it does

# How Has This Been Tested?

Tested the `submitNewsPost` API endpoint in Postman:
- With session cookie and user ID of admin user specified in the request, the news post is created.
- With session cookie and user ID of a non-admin user specified, `Error: Unauthorized` is returned.
- If the `userId` provided is an admin user but the session cookie does not match the `session` of this `userId`, the request will be blocked (existing functionality) with the error `Forbidden`.