### PR TITLE
F2P-148 | KDR and `BodyText` fixes

### DIFF
--- a/src/components/atoms/BodyText/BodyText.tsx
+++ b/src/components/atoms/BodyText/BodyText.tsx
@@ -15,6 +15,7 @@ export const BodyText = styled(Typography, {
   shouldForwardProp: prop => !['topMargin', 'bodyTextAlign'].includes(prop.toString()),
 })<BodyTextProps>(
   ({ theme, topMargin, bodyTextAlign }) => css`
+    display: block;
     margin-top: ${topMargin || 20}px;
     text-align: center;
 

--- a/src/components/molecules/CharacterInfoModal/CharacterInfoModal.styled.tsx
+++ b/src/components/molecules/CharacterInfoModal/CharacterInfoModal.styled.tsx
@@ -36,3 +36,9 @@ export const KdrTooltip = styled(({ className, ...props }: TooltipProps) => (
     fontSize: 14,
   },
 }))
+
+export const LoadingText = styled('em')(
+  () => css`
+    color: gray;
+  `,
+)

--- a/src/components/molecules/CharacterInfoModal/CharacterInfoModal.tsx
+++ b/src/components/molecules/CharacterInfoModal/CharacterInfoModal.tsx
@@ -2,8 +2,8 @@ import { useState } from 'react'
 import { CharacterInfoModalProps } from './CharacterInfoModal.types'
 import { Modal } from '@molecules/Modal'
 import { sendApiRequest } from '@helpers/api/apiUtils'
-import { KdrTooltip, KillsAndDeaths, ViewButton } from './CharacterInfoModal.styled'
-import { pluralize } from '@helpers/string/stringUtils'
+import { KdrTooltip, KillsAndDeaths, LoadingText, ViewButton } from './CharacterInfoModal.styled'
+import { convertNumberToOneDecimalPoint, pluralize } from '@helpers/string/stringUtils'
 import { getPrettyDateStringFromMillis } from '@helpers/date/date'
 
 const CharacterInfoModal = (props: CharacterInfoModalProps) => {
@@ -38,15 +38,19 @@ const CharacterInfoModal = (props: CharacterInfoModalProps) => {
   }
 
   const calculateKdr = (kills: string, deaths: string) => {
-    if (Number(kills) === 0 || Number(deaths) === 0) return '0'
+    const numKills = Number(kills)
+    const numDeaths = Number(deaths)
 
-    const rawKdr = Number(kills) / Number(deaths)
-    return (Math.round(rawKdr * 10) / 10).toFixed(1).toString()
+    if (numKills === 0 && numDeaths === 0) return '0.0'
+    if (numDeaths === 0) return convertNumberToOneDecimalPoint(numKills)
+
+    const rawKdr = numKills / numDeaths
+    return convertNumberToOneDecimalPoint(rawKdr)
   }
 
   const renderKdr = () => {
     if (isLoading) {
-      return <span>Loading...</span>
+      return <LoadingText>Loading...</LoadingText>
     }
 
     if (!kills || !deaths) {

--- a/src/helpers/string/stringUtils.ts
+++ b/src/helpers/string/stringUtils.ts
@@ -12,3 +12,6 @@ export const GetRandomToken = () => {
 }
 
 export const pluralize = (number: number, text: string) => (number === 1 ? text : `${text}s`)
+
+/** Rounds a number to 1 decimal point and converts it to a string. */
+export const convertNumberToOneDecimalPoint = (number: number) => (Math.round(number * 10) / 10).toFixed(1).toString()


### PR DESCRIPTION
# What's Changed

- Fixed KDR calculation error if deaths are 0
- Fixed issue with `BodyText` properties not working in some modals
- Refactored some of the KDR code

# Testing Notes

- KDR calculations work as expected now.
- Password and rename modal body text is aligned and spaced correctly now.