### PR TITLE
F2P-162 | Need to hide mods from hiscores

### DIFF
--- a/src/pages/api/getPlayerHiscore/index.ts
+++ b/src/pages/api/getPlayerHiscore/index.ts
@@ -18,7 +18,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse<User>) => {
     e.magic AS 'magicxp', ms.cooking, e.cooking AS 'cookingxp', ms.woodcut, e.woodcut AS 'woodcutxp', ms.fishing, 
     e.fishing AS 'fishingxp', ms.firemaking, e.firemaking AS 'firemakingxp', ms.crafting, e.crafting AS 'craftingxp',
     ms.smithing, e.smithing AS 'smithingxp', ms.mining, e.mining AS 'miningxp' FROM maxstats ms
-    JOIN players p ON p.id = ms.playerID JOIN experience e ON e.playerID = p.id WHERE p.group_id != 0 AND p.banned = 0`
+    JOIN players p ON p.id = ms.playerID JOIN experience e ON e.playerID = p.id WHERE p.group_id = 10 AND p.banned = 0`
 
   return handleQuery<HiscoreDataRow>('game', query, res)
 }

--- a/src/pages/api/queryHiscores/index.ts
+++ b/src/pages/api/queryHiscores/index.ts
@@ -10,7 +10,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse<User>) => {
   e.woodcut AS 'woodcutxp', ms.fishing, e.fishing AS 'fishingxp', ms.firemaking, e.firemaking AS 'firemakingxp', ms.crafting,
   e.crafting AS 'craftingxp', ms.smithing, e.smithing AS 'smithingxp', ms.mining,
   e.mining AS 'miningxp' FROM maxstats ms JOIN players p ON p.id = ms.playerID
-  JOIN experience e ON e.playerID = p.id WHERE p.group_id != 0 AND p.banned = 0`
+  JOIN experience e ON e.playerID = p.id WHERE p.group_id = 10 AND p.banned = 0`
 
   return handleQuery<HiscoreDataRow>('game', query, res)
 }


### PR DESCRIPTION
# What's Changed

- Updated hiscores queries to return data for normal players only

# Testing Notes

- Mods and admins do not show in hiscores and cannot be looked up