### PR TITLE
F2P-164 | Users cannot rename to lowercase or uppercase

### DIFF
--- a/src/components/organisms/RenameAccountModal/RenameAccountModal.tsx
+++ b/src/components/organisms/RenameAccountModal/RenameAccountModal.tsx
@@ -6,7 +6,6 @@ import { Field } from '@atoms/Field'
 import { handleForbiddenRedirect, sendApiRequest } from '@helpers/api/apiUtils'
 import { User } from '@globalTypes/User'
 import { AxiosError } from 'axios'
-import { AxiosErrorResponse } from '@globalTypes/AxiosErrorResponse'
 
 type RenameAccountModalProps = {
   account: PlayerDataRow

--- a/src/components/organisms/RenameAccountModal/RenameAccountModal.tsx
+++ b/src/components/organisms/RenameAccountModal/RenameAccountModal.tsx
@@ -5,6 +5,8 @@ import { Modal } from '@molecules/Modal'
 import { Field } from '@atoms/Field'
 import { handleForbiddenRedirect, sendApiRequest } from '@helpers/api/apiUtils'
 import { User } from '@globalTypes/User'
+import { AxiosError } from 'axios'
+import { AxiosErrorResponse } from '@globalTypes/AxiosErrorResponse'
 
 type RenameAccountModalProps = {
   account: PlayerDataRow
@@ -70,8 +72,15 @@ const RenameAccountModal = (props: RenameAccountModalProps) => {
           console.log(errorMessage)
         }
       })
-      .catch((error: string) => {
-        handleForbiddenRedirect(error)
+      .catch((error: AxiosError<string>) => {
+        if (error?.response?.data?.includes('No rows affected')) {
+          // Usually means they tried to rename to an account that is taken in a different case and they don't own it
+          // (There cannot be multiple account names that only differ in casing, only one can login)
+          setValidationError('The new name entered is taken. Please try another one.')
+          return
+        }
+
+        handleForbiddenRedirect(error?.message)
       })
   }
 

--- a/src/globalTypes/AxiosErrorResponse.ts
+++ b/src/globalTypes/AxiosErrorResponse.ts
@@ -1,0 +1,6 @@
+export type AxiosErrorResponse = {
+  // response: {
+  /** Usually this is the error message. */
+  data: string
+  // }
+}

--- a/src/globalTypes/AxiosErrorResponse.ts
+++ b/src/globalTypes/AxiosErrorResponse.ts
@@ -1,6 +1,0 @@
-export type AxiosErrorResponse = {
-  // response: {
-  /** Usually this is the error message. */
-  data: string
-  // }
-}

--- a/src/helpers/api/apiHandler.ts
+++ b/src/helpers/api/apiHandler.ts
@@ -59,6 +59,6 @@ export const handleManipulate = async (
     console.log('An error occurred in the handleManipulate API handler: ', error)
     res.statusCode = 500
     res.setHeader('Content-Type', 'application/json')
-    res.end(JSON.stringify(`${error?.toString()}`))
+    res.end(JSON.stringify(error?.toString()))
   }
 }

--- a/src/helpers/api/apiUtils.ts
+++ b/src/helpers/api/apiUtils.ts
@@ -73,7 +73,7 @@ export const handleForbiddenRedirect = (error: string) => {
   // If the error is an HTTP 403, it means the user's session cookie value
   // no longer matches the one that was saved when they last logged in.
   // Log the user out and redirect to the Session Expired page.
-  if (error.toString().includes('403') || error.toString().toLowerCase().includes('forbidden')) {
+  if (error.includes('403') || error.toLowerCase().includes('forbidden')) {
     sendApiRequest('GET', '/api/ironLogout')
       .then(() => {
         redirectTo('/account/session-expired')

--- a/src/pages/api/updateGameAccountUsername/index.ts
+++ b/src/pages/api/updateGameAccountUsername/index.ts
@@ -14,10 +14,14 @@ const handler = async (req: NextApiRequest, res: NextApiResponse<User>) => {
     return
   }
 
+  // The 2nd line ensures that the case-sensitive new name isn't taken.
+  // The 3rd line ensures that the username returned from the new name search is theirs.
   const query = `UPDATE players SET former_name = ?, username = ? WHERE id = ? AND websiteUserId = ?
-    AND NOT EXISTS (SELECT username FROM players WHERE username = ?) AND former_name = ''`
+    AND NOT EXISTS (SELECT username FROM players WHERE BINARY username = ?) 
+      AND (SELECT username FROM players WHERE username = ?) = ?
+        AND former_name = ''`
 
-  return handleManipulate('game', query, res, [currentName, newName, accountId, userId, newName])
+  return handleManipulate('game', query, res, [currentName, newName, accountId, userId, newName, newName, currentName])
 }
 
 export default handler


### PR DESCRIPTION
# What's Changed

- Made changes to rename logic so players can rename their account to the same name but with a different case
- Removed some unnecessary `.toString()` and `${}` code

# Fixes
https://github.com/aldrichdev/neatf2p-nextjs/issues/107

# Testing Notes

- Code works as intended, I can rename to an uppercase, lowercase, or mixed case of the same name.
- I cannot rename to a different case of a completely different name