### PR TITLE
Account rename bug fix

### DIFF
--- a/src/components/organisms/PasswordModal/PasswordModal.tsx
+++ b/src/components/organisms/PasswordModal/PasswordModal.tsx
@@ -6,6 +6,7 @@ import { hashPassword } from '@helpers/password'
 import { sanitizeRunescapePassword } from '@helpers/string/stringUtils'
 import { handleForbiddenRedirect, sendApiRequest } from '@helpers/api/apiUtils'
 import { User } from '@globalTypes/User'
+import { AxiosError } from 'axios'
 
 type PasswordModalProps = {
   account: PlayerDataRow
@@ -72,7 +73,7 @@ const PasswordModal = (props: PasswordModalProps) => {
           console.log(errorMessage)
         }
       })
-      .catch((error: string) => {
+      .catch((error: AxiosError<string>) => {
         handleForbiddenRedirect(error)
       })
   }

--- a/src/components/organisms/RenameAccountModal/RenameAccountModal.tsx
+++ b/src/components/organisms/RenameAccountModal/RenameAccountModal.tsx
@@ -79,7 +79,7 @@ const RenameAccountModal = (props: RenameAccountModalProps) => {
           return
         }
 
-        handleForbiddenRedirect(error?.message)
+        handleForbiddenRedirect(error)
       })
   }
 

--- a/src/helpers/api/apiUtils.ts
+++ b/src/helpers/api/apiUtils.ts
@@ -1,5 +1,5 @@
 import { redirectTo } from '@helpers/window'
-import axios from 'axios'
+import axios, { AxiosError } from 'axios'
 import { NextApiResponse } from 'next'
 
 /** This type comprises all the possible types of values in body properties. */
@@ -69,11 +69,11 @@ export const sendBadRequest = (res: NextApiResponse, errorMessage: string) => {
   return
 }
 
-export const handleForbiddenRedirect = (error: string) => {
+export const handleForbiddenRedirect = (error: AxiosError<string>) => {
   // If the error is an HTTP 403, it means the user's session cookie value
   // no longer matches the one that was saved when they last logged in.
   // Log the user out and redirect to the Session Expired page.
-  if (error.includes('403') || error.toLowerCase().includes('forbidden')) {
+  if (error?.response?.status === 403 || error?.response?.data?.toLowerCase().includes('forbidden')) {
     sendApiRequest('GET', '/api/ironLogout')
       .then(() => {
         redirectTo('/account/session-expired')

--- a/src/hooks/useGameAccounts.ts
+++ b/src/hooks/useGameAccounts.ts
@@ -1,5 +1,6 @@
 import { PlayerDataRow } from '@globalTypes/Database/PlayerDataRow'
 import { handleForbiddenRedirect, sendApiRequest } from '@helpers/api/apiUtils'
+import { AxiosError } from 'axios'
 import { useEffect, useState } from 'react'
 
 const useGameAccounts = (userId: string | undefined) => {
@@ -11,8 +12,8 @@ const useGameAccounts = (userId: string | undefined) => {
         .then(response => {
           setAccounts(response.data)
         })
-        .catch((error: string) => {
-          console.log(error)
+        .catch((error: AxiosError<string>) => {
+          console.log('Error getting game accounts:', error)
           handleForbiddenRedirect(error)
         })
     }

--- a/src/pages/account/change-email/[id].tsx
+++ b/src/pages/account/change-email/[id].tsx
@@ -5,6 +5,7 @@ import { handleForbiddenRedirect, sendApiRequest } from '@helpers/api/apiUtils'
 import { renderHead } from '@helpers/renderUtils'
 import useAuthentication from '@hooks/useAuthentication'
 import { Spinner } from '@molecules/Spinner'
+import { AxiosError } from 'axios'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
@@ -26,7 +27,7 @@ const ChangeEmailByIdPage = () => {
       .then(() => {
         setIsLoading(false)
       })
-      .catch((error: string) => {
+      .catch((error: AxiosError<string>) => {
         handleForbiddenRedirect(error)
       })
   }, [accountId, newEmail, user.id])

--- a/src/pages/account/change-password/index.tsx
+++ b/src/pages/account/change-password/index.tsx
@@ -12,6 +12,7 @@ import { FieldValidationMessage } from '@atoms/FieldValidationMessage'
 import { hashPassword } from '@helpers/password'
 import { handleForbiddenRedirect, sendApiRequest } from '@helpers/api/apiUtils'
 import { renderHead } from '@helpers/renderUtils'
+import { AxiosError } from 'axios'
 
 const ChangePasswordPage = () => {
   const [isLoading, setIsLoading] = useState(true)
@@ -61,7 +62,7 @@ const ChangePasswordPage = () => {
           setFormValidationError(`Something went wrong. Please try again later. Error: ${errorMessage}`)
         }
       })
-      .catch((error: string) => {
+      .catch((error: AxiosError<string>) => {
         handleForbiddenRedirect(error)
       })
   }

--- a/src/pages/account/change-username/index.tsx
+++ b/src/pages/account/change-username/index.tsx
@@ -14,6 +14,7 @@ import { handleForbiddenRedirect, sendApiRequest } from '@helpers/api/apiUtils'
 import { UserIsLoggedIn } from '@helpers/users/users'
 import { NotLoggedIn } from '@molecules/NotLoggedIn'
 import { renderHead } from '@helpers/renderUtils'
+import { AxiosError } from 'axios'
 
 const ChangeUsernamePage = () => {
   const [isLoading, setIsLoading] = useState(true)
@@ -67,7 +68,7 @@ const ChangeUsernamePage = () => {
       .then(() => {
         redirectTo('/account/change-username/success')
       })
-      .catch((error: string) => {
+      .catch((error: AxiosError<string>) => {
         handleForbiddenRedirect(error)
       })
   }

--- a/src/pages/account/game-accounts/create/index.tsx
+++ b/src/pages/account/game-accounts/create/index.tsx
@@ -14,7 +14,7 @@ import { Spinner } from '@molecules/Spinner'
 import { PageHeading } from '@atoms/PageHeading'
 import { sanitizeRunescapePassword } from '@helpers/string/stringUtils'
 import { handleForbiddenRedirect, sendApiRequest } from '@helpers/api/apiUtils'
-import axios from 'axios'
+import axios, { AxiosError } from 'axios'
 import { renderHead } from '@helpers/renderUtils'
 import { RulesAcceptanceCheckbox } from '@molecules/RulesAcceptanceCheckbox'
 
@@ -86,17 +86,17 @@ const CreateGameAccount = () => {
                   redirectTo(`/account/game-accounts/create/success?accountName=${accountName}`)
                 }
               })
-              .catch((error: { response: { data: string } }) => {
+              .catch((error: AxiosError<string>) => {
                 setSubmitDisabled(false)
-                setValidationError(error.response.data)
-                handleForbiddenRedirect(error.response.data)
+                setValidationError(error?.response?.data || '')
+                handleForbiddenRedirect(error)
               })
           }
         })
-        .catch((error: { response: { data: string } }) => {
+        .catch((error: AxiosError<string>) => {
           setSubmitDisabled(false)
-          setValidationError(error.response.data)
-          handleForbiddenRedirect(error.response.data)
+          setValidationError(error?.response?.data || '')
+          handleForbiddenRedirect(error)
         })
     })
   }

--- a/src/pages/admin/newsPostForm/index.tsx
+++ b/src/pages/admin/newsPostForm/index.tsx
@@ -29,6 +29,7 @@ import CloudUploadIcon from '@mui/icons-material/CloudUpload'
 import { ContentBlock } from '@atoms/ContentBlock'
 import { handleForbiddenRedirect, sendApiRequest } from '@helpers/api/apiUtils'
 import { renderHead } from '@helpers/renderUtils'
+import { AxiosError } from 'axios'
 
 const NewsPostForm = () => {
   const [loading, setLoading] = useState(true)
@@ -105,12 +106,12 @@ const NewsPostForm = () => {
           code: response?.data?.includes('Success') ? 'green' : 'red',
         })
       })
-      .catch((error: { response: { data: string } }) => {
+      .catch((error: AxiosError<string>) => {
         setSubmitResult({
-          answer: error.response.data,
+          answer: error?.response?.data || '',
           code: 'red',
         })
-        handleForbiddenRedirect(error.response.data)
+        handleForbiddenRedirect(error)
       })
   }
 

--- a/src/pages/api/updateGameAccountUsername/index.ts
+++ b/src/pages/api/updateGameAccountUsername/index.ts
@@ -15,13 +15,13 @@ const handler = async (req: NextApiRequest, res: NextApiResponse<User>) => {
   }
 
   // The 2nd line ensures that the case-sensitive new name isn't taken.
-  // The 3rd line ensures that the username returned from the new name search is theirs.
+  // The 3rd line ensures that the username returned from the search is theirs.
   const query = `UPDATE players SET former_name = ?, username = ? WHERE id = ? AND websiteUserId = ?
     AND NOT EXISTS (SELECT username FROM players WHERE BINARY username = ?) 
-      AND (SELECT username FROM players WHERE username = ?) = ?
+      AND ? IN (SELECT username FROM players WHERE websiteUserId = ?)
         AND former_name = ''`
 
-  return handleManipulate('game', query, res, [currentName, newName, accountId, userId, newName, newName, currentName])
+  return handleManipulate('game', query, res, [currentName, newName, accountId, userId, newName, currentName, userId])
 }
 
 export default handler


### PR DESCRIPTION
# What's Changed

- Fixed issue with account renames not working
- Fixed typing of API errors in FE by changing all error types to `AxiosError<string>`
- Fixed issue in `handleForbiddenRedirect` due to the `error` parameter being the wrong type

# Testing Notes

Made sure account renames work now on the website, and renaming to the same name but in a different case still works.