### PR TITLE
F2P-142 | Plus signs in email addresses ➡ users cannot login

### DIFF
--- a/src/pages/account/login/index.tsx
+++ b/src/pages/account/login/index.tsx
@@ -70,7 +70,7 @@ const AccountLoginPage = () => {
     event.preventDefault()
     setButtonDisabled(true)
 
-    sendApiRequest('GET', `/api/getUser?email=${email}`)
+    sendApiRequest('GET', `/api/getUser?email=${encodeURIComponent(email)}`)
       .then(async response => {
         const result = response?.data
 


### PR DESCRIPTION
# What's Changed

- Fixed issue with website accounts not being able to log in if their email address has a plus sign (or any other odd character)

# Testing Notes

- Confirmed I can log in with an email address `my+email@gmail.com` with no errors or warnings. Other email addresses without special characters still work fine and can login.