### PR TITLE
F2P-133 | News post preview modal doesn't handle long posts well

### DIFF
--- a/src/components/molecules/Modal/Modal.styled.ts
+++ b/src/components/molecules/Modal/Modal.styled.ts
@@ -1,3 +1,4 @@
+import { BodyText } from '@atoms/BodyText'
 import { Typography } from '@mui/material'
 import { styled } from '@mui/material/styles'
 import { css } from '@mui/system'
@@ -14,10 +15,8 @@ export const ModalOverlay = styled('div')(
   `,
 )
 
-export const ModalRoot = styled('div', {
-  shouldForwardProp: prop => prop !== 'open',
-})<{ open: boolean }>(
-  ({ theme, open }) => css`
+export const ModalRoot = styled('div')(
+  ({ theme }) => css`
     position: absolute;
     left: 0;
     right: 0;
@@ -25,19 +24,10 @@ export const ModalRoot = styled('div', {
     background-color: white;
     padding: 16px 32px 32px 32px;
 
-    ${
-      /** TODO: Do we still need this? Is it doing anything? seems to do nothing on mac? */
-      open &&
-      `
-      overflow-y: hidden;
-      max-height: 100vh;
-      `
-    }
-
     ${theme.breakpoints.up('tablet')} {
       left: 25%;
       right: 25%;
-      top: 25%;
+      top: 15%;
     }
   `,
 )
@@ -66,5 +56,21 @@ export const ModalHeader = styled(Typography)(
     ${theme.breakpoints.down('tablet')} {
       font-size: 32px;
     }
+  `,
+)
+
+export const ScrollableContainer = styled('div')(
+  () => css`
+    position: relative;
+    height: 400px;
+  `,
+)
+
+export const ModalBody = styled(BodyText)(
+  () => css`
+    position: absolute;
+    overflow-y: scroll;
+    height: 100%;
+    display: block;
   `,
 )

--- a/src/components/molecules/Modal/Modal.styled.ts
+++ b/src/components/molecules/Modal/Modal.styled.ts
@@ -66,11 +66,9 @@ export const ScrollableContainer = styled('div')(
   `,
 )
 
-export const ModalBody = styled(BodyText)(
+export const ScrollableBody = styled(BodyText)(
   () => css`
-    position: absolute;
     overflow-y: scroll;
     height: 100%;
-    display: block;
   `,
 )

--- a/src/components/molecules/Modal/Modal.tsx
+++ b/src/components/molecules/Modal/Modal.tsx
@@ -6,8 +6,8 @@ import {
   ModalHeader,
   ModalOverlay,
   ModalRoot,
-  ModalBody,
   ScrollableContainer,
+  ScrollableBody,
 } from './Modal.styled'
 import { Form } from '@atoms/Form'
 import { FormButton } from '@atoms/FormButton/FormButton'
@@ -42,9 +42,9 @@ const Modal = (props: ModalProps) => {
         <ModalHeader variant='h3'>{heading}</ModalHeader>
         {bodyScrollable ? (
           <ScrollableContainer>
-            <ModalBody variant='body' component='span' bodyTextAlign='left'>
+            <ScrollableBody variant='body' component='span' bodyTextAlign='left'>
               {body}
-            </ModalBody>
+            </ScrollableBody>
           </ScrollableContainer>
         ) : (
           <BodyText variant='body' component='span' bodyTextAlign='left'>

--- a/src/components/molecules/Modal/Modal.tsx
+++ b/src/components/molecules/Modal/Modal.tsx
@@ -1,5 +1,14 @@
 import { BodyText } from '@atoms/BodyText'
-import { CloseBar, CloseButton, CloseIcon, ModalHeader, ModalOverlay, ModalRoot } from './Modal.styled'
+import {
+  CloseBar,
+  CloseButton,
+  CloseIcon,
+  ModalHeader,
+  ModalOverlay,
+  ModalRoot,
+  ModalBody,
+  ScrollableContainer,
+} from './Modal.styled'
 import { Form } from '@atoms/Form'
 import { FormButton } from '@atoms/FormButton/FormButton'
 import { FieldValidationMessage } from '@atoms/FieldValidationMessage'
@@ -17,22 +26,31 @@ const Modal = (props: ModalProps) => {
     renderFields,
     formValidationError,
     formSuccessMessage,
+    bodyScrollable,
   } = props
 
   if (!open) return null
 
   return (
     <ModalOverlay>
-      <ModalRoot open={open}>
+      <ModalRoot>
         <CloseBar>
           <CloseButton onClick={handleClose}>
             <CloseIcon src='/img/close-icon.webp' alt='' />
           </CloseButton>
         </CloseBar>
         <ModalHeader variant='h3'>{heading}</ModalHeader>
-        <BodyText variant='body' component='span' bodyTextAlign='left'>
-          {body}
-        </BodyText>
+        {bodyScrollable ? (
+          <ScrollableContainer>
+            <ModalBody variant='body' component='span' bodyTextAlign='left'>
+              {body}
+            </ModalBody>
+          </ScrollableContainer>
+        ) : (
+          <BodyText variant='body' component='span' bodyTextAlign='left'>
+            {body}
+          </BodyText>
+        )}
         {hasForm && handleSubmit && renderFields && (
           <>
             <Form onSubmit={handleSubmit}>

--- a/src/components/molecules/Modal/Modal.types.ts
+++ b/src/components/molecules/Modal/Modal.types.ts
@@ -12,4 +12,5 @@ export type ModalProps = {
   renderFields?: () => JSX.Element
   formValidationError?: string
   formSuccessMessage?: string
+  bodyScrollable?: boolean
 }

--- a/src/pages/admin/newsPostForm/index.tsx
+++ b/src/pages/admin/newsPostForm/index.tsx
@@ -189,6 +189,7 @@ const NewsPostForm = () => {
                 <ReactMarkdown className='news-post-body-markdown'>{body}</ReactMarkdown>
               </>
             }
+            bodyScrollable
           />
           <SubmitArea>
             <SubmitButton variant='contained' type='submit' disabled={submitDisabled}>


### PR DESCRIPTION
# What's Changed

- Made news post form preview modal scrollable so the entire body can be read
- Removed unnecessary code and `TODO`. (This may cause the content shift in the game accounts table to be a bit more pronounced when opening a modal than it was before, but it was a half-effective solution anyway, and will be fully addressed in `F2P-58`)

# Testing Notes

- Preview modal is now less tall and has a scrollable body.
- Other modals are unaffected except for a slight change to the `top` % for the absolutely positioned modal. It does not look bad.