### PR TITLE
F2P-172 | Make header image fade down

### DIFF
--- a/src/components/MainNavigationDropdownItem/MainNavigationDropdownItem.styled.ts
+++ b/src/components/MainNavigationDropdownItem/MainNavigationDropdownItem.styled.ts
@@ -12,14 +12,19 @@ export const NavItem = styled('div')(
 export const NavButton = styled(Button, {
   shouldForwardProp: prop => prop !== 'isActive',
 })<{ isActive?: boolean }>(
-  ({ isActive }) => css`
+  ({ theme, isActive }) => css`
     ${getBaseNavItemStyles(isActive)}
     font-family: Source Sans Pro;
     font-size: 20px;
     border-radius: 0;
+    height: 43px;
 
     :hover {
       color: white;
+    }
+
+    ${theme.breakpoints.up('tablet')} {
+      height: auto;
     }
   `,
 )

--- a/src/components/atoms/MainNavigation/MainNavigation.styled.ts
+++ b/src/components/atoms/MainNavigation/MainNavigation.styled.ts
@@ -20,8 +20,7 @@ export const NavUnorderedList = styled('ul')(
     align-items: center;
     font-family: Source Sans Pro;
     font-size: 20px;
-    column-gap: 16px;
-    row-gap: 16px;
+    gap: 16px;
     background-color: var(--dark-gray);
     border: 0;
     padding: 12px 0;

--- a/src/components/atoms/MainNavigation/MainNavigation.styled.ts
+++ b/src/components/atoms/MainNavigation/MainNavigation.styled.ts
@@ -13,7 +13,6 @@ export const NavContainer = styled('div')(
 export const NavUnorderedList = styled('ul')(
   ({ theme }) => css`
     list-style-type: none;
-    margin: 20px 0 10px;
     padding: 0;
     display: flex;
     flex-wrap: wrap;
@@ -22,14 +21,15 @@ export const NavUnorderedList = styled('ul')(
     font-family: Source Sans Pro;
     font-size: 20px;
     column-gap: 16px;
-    row-gap: 32px;
+    row-gap: 16px;
     background-color: var(--dark-gray);
     border: 0;
     padding: 12px 0;
-    width: 1200px;
+    width: 100%;
 
     ${theme.breakpoints.up('tablet')} {
       border: 2px solid black;
+      row-gap: 32px;
     }
 
     ${theme.breakpoints.up('desktop')} {

--- a/src/styledPages/App.styled.ts
+++ b/src/styledPages/App.styled.ts
@@ -28,6 +28,7 @@ export const HomepageLink = styled(Link)(
 export const Logo = styled('img')(
   () => css`
     width: 100%;
+    display: block;
   `,
 )
 


### PR DESCRIPTION
# What's Changed

- Moved navigation closer to header image
- Fixed mobile view of navigation

# Notes

It was decided not to make the header image fade down, as what I implemented here looked better.