### PR TITLE
F2P-160 | Error on account creation needs tweaking

### DIFF
--- a/src/pages/account/create/index.tsx
+++ b/src/pages/account/create/index.tsx
@@ -82,7 +82,6 @@ const CreateAccountPage = () => {
     })
       .then(response => {
         if (response?.status !== 200) {
-          // Display error to user (usually due to a taken email or username).
           setSubmitDisabled(false)
           setValidationError(response?.data)
         } else if (typeof response?.data === 'string') {
@@ -129,7 +128,14 @@ const CreateAccountPage = () => {
       })
       .catch((error: { response: { data: string } }) => {
         setSubmitDisabled(false)
-        setValidationError(error.response.data)
+
+        // An exception can happen if the email address or username are taken.
+        // We need to check if there are no rows affected, because this means the query didn't insert anything.
+        if (error.response.data.toLowerCase().includes('no rows affected')) {
+          setValidationError('The email address or username you entered is already taken. Please choose another one.')
+        } else {
+          setValidationError(error.response.data)
+        }
       })
   }
 

--- a/src/pages/api/createUserAccount/index.ts
+++ b/src/pages/api/createUserAccount/index.ts
@@ -42,6 +42,10 @@ const handler = async (req: NextApiRequest, res: NextApiResponse<User>) => {
       return
     }
 
+    if (insertUserResponse?.affectedRows < 1) {
+      throw new Error(`No rows affected. Response: ${insertUserResponse}`)
+    }
+
     // Return a JSON result indicating success
     res.statusCode = 200
     res.setHeader('Content-Type', 'application/json')


### PR DESCRIPTION
# What's Changed

- Fixed error message when visitors try to create new website accounts

# How Tested

- Users that try to create a new website account with an email or username that is already taken are presented with a more meaningful and clear error message
- Users can still create new website accounts