### PR TITLE
F2P-175 | Lists in news post preview modal not appearing correctly

### DIFF
--- a/src/components/MainNavigationDropdownItem/MainNavigationDropdownItem.styled.ts
+++ b/src/components/MainNavigationDropdownItem/MainNavigationDropdownItem.styled.ts
@@ -36,6 +36,14 @@ export const NavDropdownMenu = styled('div')(
   `,
 )
 
+export const NavDropdownMenuSubItemList = styled('ul')(
+  () => css`
+    list-style-type: none;
+    padding: 0;
+    margin: 0;
+  `,
+)
+
 export const NavSubItem = styled('li')(
   () => css`
     list-style-type: none;

--- a/src/components/MainNavigationDropdownItem/MainNavigationDropdownItem.tsx
+++ b/src/components/MainNavigationDropdownItem/MainNavigationDropdownItem.tsx
@@ -1,6 +1,13 @@
 import { useState } from 'react'
 import { MainNavigationDropdownItemProps } from './MainNavigationDropdownItem.types'
-import { NavButton, NavDropdownMenu, NavItem, NavSubItem, NavSubLink } from './MainNavigationDropdownItem.styled'
+import {
+  NavButton,
+  NavDropdownMenu,
+  NavDropdownMenuSubItemList,
+  NavItem,
+  NavSubItem,
+  NavSubLink,
+} from './MainNavigationDropdownItem.styled'
 
 const MainNavigationDropdownItem = (props: MainNavigationDropdownItemProps) => {
   const { title, subItems, isItemActive } = props
@@ -22,13 +29,13 @@ const MainNavigationDropdownItem = (props: MainNavigationDropdownItemProps) => {
       </NavButton>
       {isDropdownVisible && (
         <NavDropdownMenu>
-          <ul>
+          <NavDropdownMenuSubItemList>
             {subItems.map(subItem => (
               <NavSubItem key={subItem.path}>
                 <NavSubLink href={subItem.path}>{subItem.text}</NavSubLink>
               </NavSubItem>
             ))}
-          </ul>
+          </NavDropdownMenuSubItemList>
         </NavDropdownMenu>
       )}
     </NavItem>

--- a/src/components/atoms/MainNavigation/MainNavigation.styled.ts
+++ b/src/components/atoms/MainNavigation/MainNavigation.styled.ts
@@ -14,6 +14,7 @@ export const NavUnorderedList = styled('ul')(
   ({ theme }) => css`
     list-style-type: none;
     padding: 0;
+    margin: 0;
     display: flex;
     flex-wrap: wrap;
     justify-content: center;

--- a/src/theme/styles.css
+++ b/src/theme/styles.css
@@ -10,12 +10,6 @@ body {
   margin: 0;
 }
 
-ul {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-
 a {
   color: green;
 }


### PR DESCRIPTION
# What's Changed

- Fixed issue in news post form preview where bullets weren't showing for lists
- Removed default CSS for `ul` element from `styles.css`
- Updated other places where `ul` elements are used to remove padding and default bullet

# How Tested?

- Confirmed bullets appear in the preview modal now
- Confirmed main navigation, about page info section and hiscores menu item list all look good
