### PR TITLE
F2P-209 | Account rename -  Existing username should should be insensitive

### DIFF
--- a/src/pages/api/updateGameAccountUsername/index.ts
+++ b/src/pages/api/updateGameAccountUsername/index.ts
@@ -14,14 +14,23 @@ const handler = async (req: NextApiRequest, res: NextApiResponse<User>) => {
     return
   }
 
-  // The 2nd line ensures that the case-sensitive new name isn't taken.
+  // The 2nd line ensures that the case-insensitive new name isn't taken by someone else.
   // The 3rd line ensures that the username returned from the search is theirs.
   const query = `UPDATE players SET former_name = ?, username = ? WHERE id = ? AND websiteUserId = ?
-    AND NOT EXISTS (SELECT username FROM players WHERE BINARY username = ?) 
+    AND NOT EXISTS (SELECT username FROM players WHERE username = ? AND id != ?)
       AND ? IN (SELECT username FROM players WHERE websiteUserId = ?)
         AND former_name = ''`
 
-  return handleManipulate('game', query, res, [currentName, newName, accountId, userId, newName, currentName, userId])
+  return handleManipulate('game', query, res, [
+    currentName,
+    newName,
+    accountId,
+    userId,
+    newName,
+    accountId,
+    currentName,
+    userId,
+  ])
 }
 
 export default handler


### PR DESCRIPTION
# What's Changed
- Fixed issue with users being able to rename their game accounts to the same name but different casing of another user
- Kept functionality that allows users to rename their accounts to a different casing of the same name, by adding an ID check
