### PR TITLE
F2P-220 | Potential fix for Last Login date showing in GMT time

### DIFF
--- a/src/pages/hiscores/player/[accountName].tsx
+++ b/src/pages/hiscores/player/[accountName].tsx
@@ -176,7 +176,8 @@ export const getServerSideProps: GetServerSideProps = async ({ params }) => {
   if (output) {
     const hiscores: PlayerHiscoreDataRow[] = output
 
-    // Get player last login date as a millis number
+    // Get player last login date as a millis number.
+    // A value of 0 for millis means the user has never logged in. Likewise for undefined.
     const lastLoginMillis = hiscores.find(
       (row: PlayerHiscoreDataRow) => row.username.toLowerCase() === accountName.toLowerCase(),
     )?.login_date


### PR DESCRIPTION
# What's Changed

- Updated player hiscore page server-side code to return the last login value as a millis and have the client-side render it as a string - this may fix an issue with these login dates showing in GMT