### PR TITLE
Add V A H O V A to Hall of Fame

### DIFF
--- a/src/components/atoms/CommunityAchievementsTable/CommunityAchievements.data.ts
+++ b/src/components/atoms/CommunityAchievementsTable/CommunityAchievements.data.ts
@@ -136,8 +136,8 @@ export const communityAchievements = [
   },
   {
     achievement: 'First to 99 Smithing',
-    playerName: 'TBD',
-    date: 'TBD',
+    playerName: 'V A H O V A',
+    date: '11/23/2025',
   },
   {
     achievement: 'First to 99 Mining',


### PR DESCRIPTION
# What's Changed

- Added V A H O V A to the Hall of Fame in anticipation of his achievement on 11/23
