### PR TITLE
F2P-218 | Add og:title, fix CSS and keywords issues

### DIFF
--- a/src/components/molecules/NewsPostDetailItem/NewsPostDetailItem.styled.ts
+++ b/src/components/molecules/NewsPostDetailItem/NewsPostDetailItem.styled.ts
@@ -45,6 +45,7 @@ export const NewsPostDetailBody = styled(Typography)<ExtendedTypographyProps>(
   ({ theme }) => css`
     display: block;
     margin: 20px 0 0;
+    overflow-wrap: break-word;
 
     ${theme.breakpoints.up('tablet')} {
       margin: 40px 0 0;

--- a/src/helpers/renderUtils.tsx
+++ b/src/helpers/renderUtils.tsx
@@ -4,15 +4,19 @@ import Head from 'next/head'
  * `title` should only include the unique part for that page.
  * Note: In this function we put the title into a `{``}` because
  * otherwise we will see `<!-- -->` in it on first render. */
-export const renderHead = (title: string, description?: string, keywords?: string) => (
-  <Head>
-    <title>{`${title} | Neat F2P`}</title>
-    {description && (
-      <>
-        <meta name='description' content={description} />
-        <meta name='og:description' content={description} />
-      </>
-    )}
-    {keywords && <meta key='keywords' content={keywords} />}
-  </Head>
-)
+export const renderHead = (title: string, description?: string, keywords?: string) => {
+  const brandedTitle = `${title} | Neat F2P`
+  const descriptionOrFallback =
+    description ||
+    'Neat F2P is a Runescape Classic (RSC) private server that is F2P only (no members) and is 100% free.'
+
+  return (
+    <Head>
+      <title>{brandedTitle}</title>
+      <meta name='og:title' content={brandedTitle} />
+      <meta name='description' content={descriptionOrFallback} />
+      <meta name='og:description' content={descriptionOrFallback} />
+      {keywords && <meta key='keywords' content={keywords} />}
+    </Head>
+  )
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -28,7 +28,7 @@ export default function App({ Component, pageProps }: AppProps) {
           content='Neat F2P is a Runescape Classic (RSC) private server that is F2P only (no members) and is 100% free.'
         />
         <meta
-          key='keywords'
+          name='keywords'
           content='neatf2p, neat f2p, f2p, f2p neat, rsc f2p, f2p rsc, rscf2p, f2prsc, runescapeclassic, runescape classic, rs classic, runescape classic f2p'
         />
       </Head>


### PR DESCRIPTION
# What's Changed

- Added `og:title` to `renderHead` to fix issue with title missing in Discord embeds
- Added CSS to break up big links in news posts as this was causing bad styling on mobile
- Fixed keywords meta tag
