### PR TITLE
F2P-230 | Hiscores page takes a while to load the first time

### DIFF
--- a/src/components/molecules/MainNavigation/MainNavigation.tsx
+++ b/src/components/molecules/MainNavigation/MainNavigation.tsx
@@ -78,7 +78,8 @@ const MainNavigation = () => {
     navigationItems.forEach(item => {
       if (item.path) prefetch(item.path)
     })
-  }, [navigationItems, prefetch])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   return (
     <NavContainer>

--- a/src/components/molecules/MainNavigation/MainNavigation.tsx
+++ b/src/components/molecules/MainNavigation/MainNavigation.tsx
@@ -2,9 +2,11 @@ import { useRouter } from 'next/router'
 import { NavUnorderedList, NavLink, NavContainer } from './MainNavigation.styled'
 import { NavigationItem } from './MainNavigation.types'
 import { MainNavigationDropdownItem } from '@atoms/MainNavigationDropdownItem'
+import { useEffect } from 'react'
 
 const MainNavigation = () => {
-  const { asPath } = useRouter()
+  const { asPath, prefetch } = useRouter()
+
   const navigationItems: NavigationItem[] = [
     {
       path: '/',
@@ -70,6 +72,13 @@ const MainNavigation = () => {
 
     return linkPath === asPath
   }
+
+  useEffect(() => {
+    // Warm up nav route chunks to remove delay previously seen when clicking around
+    navigationItems.forEach(item => {
+      if (item.path) prefetch(item.path)
+    })
+  }, [navigationItems, prefetch])
 
   return (
     <NavContainer>


### PR DESCRIPTION
# What's Changed

- Potentially fixed delay seen when clicking into Hiscores or other pages via the main navigation, due to the nav route chunks not loading on link hover (will need this to be on production to confirm 100%, but seems faster locally)