### PR TITLE
F2P-226 | Website hiscore rounding causes level/XP mismatch

### DIFF
--- a/src/utils/hiscores/hiscoresUtils.ts
+++ b/src/utils/hiscores/hiscoresUtils.ts
@@ -22,7 +22,7 @@ export const getTotalExp = (hiscoreRow: PlayerHiscoreDataRow) =>
 
 export const convertExp = (skillXP: number) => {
   // Open RSC Core Framework experience numbers are 4 times what the actual RS exp number is.
-  return Math.round(skillXP / 4).toLocaleString()
+  return Math.floor(skillXP / 4).toLocaleString()
 }
 
 export const isNotBaselineExp = (hiscore: PlayerHiscoreDataRow, propName: string) => {


### PR DESCRIPTION
# What's Changed

- Always round down hiscores EXP; before, it was rounded up, which did not match what the player sees in the game client
