### PR TITLE
F2P-213 | Player Hiscore detail page is doing too much

### DIFF
--- a/src/components/atoms/PlayerHiscoreTableRow/PlayerHiscoreTableRow.styled.ts
+++ b/src/components/atoms/PlayerHiscoreTableRow/PlayerHiscoreTableRow.styled.ts
@@ -1,0 +1,64 @@
+import { HiscoreTableValueCell } from '@molecules/HiscoresTable/HiscoresTable.styled'
+import { TableCell } from '@mui/material'
+import { styled } from '@mui/material/styles'
+import { css } from '@mui/system'
+
+export const HiscoreSkillTableCell = styled(TableCell)(
+  ({ theme }) => css`
+    display: flex;
+    align-items: center;
+    border: 0;
+    padding: 8px;
+    gap: 8px;
+
+    ${theme.breakpoints.up('tablet')} {
+      padding: 16px;
+    }
+  `,
+)
+
+export const LevelProgressBar = styled('div')(
+  ({ theme }) => css`
+    display: none;
+
+    ${theme.breakpoints.up('tablet')} {
+      display: block;
+      flex: 1;
+      height: 4px;
+      background-color: ${theme.palette.custom.levelProgressBg};
+      border-radius: 2px;
+      overflow: hidden;
+      max-width: 80px;
+    }
+  `,
+)
+
+export const LevelProgressBarFill = styled('div', {
+  shouldForwardProp: prop => prop !== 'completed',
+})<{ completed?: number }>(
+  ({ theme, completed }) => css`
+    background-color: ${theme.palette.primary.main};
+    height: 100%;
+    border-radius: 2px;
+    width: ${completed ? completed * 100 : 0}%;
+  `,
+)
+
+export const ExperienceCell = styled(HiscoreTableValueCell)(
+  ({ theme }) => css`
+    display: none;
+
+    ${theme.breakpoints.up('tablet')} {
+      display: table-cell;
+      min-width: 100px;
+    }
+  `,
+)
+
+export const MobileExperienceCell = styled(HiscoreTableValueCell)(
+  ({ theme }) => css`
+    ${theme.breakpoints.up('tablet')} {
+      display: none;
+    }
+  `,
+)

--- a/src/components/atoms/PlayerHiscoreTableRow/PlayerHiscoreTableRow.tsx
+++ b/src/components/atoms/PlayerHiscoreTableRow/PlayerHiscoreTableRow.tsx
@@ -1,0 +1,45 @@
+import { PlayerHiscoreTableRowProps } from './PlayerHiscoreTableRow.types'
+import { HiscoreTableRow, PlayerHiscoreTableCell } from '@organisms/PlayerHiscoreTable/PlayerHiscoreTable.styled'
+import { useRouter } from 'next/router'
+import { HiscoreSkillEmoji } from '@atoms/HiscoreSkillEmoji'
+import { PlayerHiscoresRank } from '@atoms/PlayerHiscoresRank'
+import { formatExp } from '@utils/string/stringUtils'
+import {
+  ExperienceCell,
+  HiscoreSkillTableCell,
+  LevelProgressBar,
+  LevelProgressBarFill,
+  MobileExperienceCell,
+} from './PlayerHiscoreTableRow.styled'
+import { convertExp } from '@utils/hiscores/hiscoresUtils'
+
+/** A component representing a single row in the player hiscore table. */
+const PlayerHiscoreTableRow = (props: PlayerHiscoreTableRowProps) => {
+  const { skill, rank, level, exp } = props
+  const router = useRouter()
+  const readableExp = convertExp(exp)
+
+  const getLevelProgressPercentage = (level: number, isTotal: boolean) => (isTotal ? 1 : level === 1 ? 0 : level / 99)
+
+  return (
+    <HiscoreTableRow onClick={() => router.push(`/hiscores?skill=${skill}`)}>
+      <HiscoreSkillTableCell sx={{ fontWeight: 500 }}>
+        <HiscoreSkillEmoji skill={skill} />
+        {skill}
+      </HiscoreSkillTableCell>
+      <PlayerHiscoreTableCell>
+        <PlayerHiscoresRank rank={rank} />
+      </PlayerHiscoreTableCell>
+      <PlayerHiscoreTableCell sx={{ fontWeight: 500 }}>
+        <span>{level}</span>
+        <LevelProgressBar>
+          <LevelProgressBarFill completed={getLevelProgressPercentage(level, skill === 'Overall')} />
+        </LevelProgressBar>
+      </PlayerHiscoreTableCell>
+      <ExperienceCell>{readableExp}</ExperienceCell>
+      <MobileExperienceCell>{formatExp(readableExp)}</MobileExperienceCell>
+    </HiscoreTableRow>
+  )
+}
+
+export default PlayerHiscoreTableRow

--- a/src/components/atoms/PlayerHiscoreTableRow/PlayerHiscoreTableRow.types.ts
+++ b/src/components/atoms/PlayerHiscoreTableRow/PlayerHiscoreTableRow.types.ts
@@ -1,0 +1,9 @@
+import { HiscoreType } from '@globalTypes/Hiscores/HiscoreType'
+
+export type PlayerHiscoreTableRowProps = {
+  skill: HiscoreType
+  rank: number
+  level: number
+  /** Raw EXP value from the database. */
+  exp: number
+}

--- a/src/components/atoms/PlayerHiscoreTableRow/index.ts
+++ b/src/components/atoms/PlayerHiscoreTableRow/index.ts
@@ -1,0 +1,1 @@
+export { default as PlayerHiscoreTableRow } from './PlayerHiscoreTableRow'

--- a/src/components/molecules/HiscoresTable/HiscoresTable.styled.ts
+++ b/src/components/molecules/HiscoresTable/HiscoresTable.styled.ts
@@ -22,7 +22,6 @@ export const HiscoreTableContainer = styled(TableContainer)<ExtendedTableContain
     }
 
     ${theme.breakpoints.up('desktop')} {
-      min-height: 1000px;
       width: 100%;
     }
   `,

--- a/src/components/molecules/HiscoresTable/HiscoresTable.tsx
+++ b/src/components/molecules/HiscoresTable/HiscoresTable.tsx
@@ -10,7 +10,7 @@ import {
   HiscoreTableHeaderCell,
   HiscoresTableHead,
 } from './HiscoresTable.styled'
-import { convertExp, getTotalExp } from '@utils/hiscores/hiscoresUtils'
+import { convertExp } from '@utils/hiscores/hiscoresUtils'
 import { HiscoresControls } from '@atoms/HiscoresControls'
 import useHiscoresPagination from '@hooks/useHiscoresPagination'
 import { HoverUnderlineLink } from '@atoms/HoverUnderlineLink'
@@ -36,13 +36,19 @@ type HiscoresTableProps = {
 
 const HiscoresTable = (props: HiscoresTableProps) => {
   const { hiscores, isLoading, hiscoreType, page, setPage } = props
+
   const { startingRecord, endingRecord, pageCount, handlePageChange } = useHiscoresPagination(
     false,
     hiscores?.length || 0,
     page,
     setPage,
   )
-  let rank = startingRecord
+
+  const getRank = (hiscore: PlayerHiscoreDataRow) => {
+    if (hiscoreType === 'Overall') return hiscore.overallRank
+
+    return hiscore[`${hiscoreType.toLowerCase()}Rank` as keyof PlayerHiscoreDataRow] as number
+  }
 
   const getHiscoreValue = (hiscore: PlayerHiscoreDataRow) => {
     switch (hiscoreType) {
@@ -56,7 +62,7 @@ const HiscoresTable = (props: HiscoresTableProps) => {
   const getHiscoreSkillXP = (hiscore: PlayerHiscoreDataRow) => {
     switch (hiscoreType) {
       case 'Overall':
-        return getTotalExp(hiscore)
+        return hiscore.totalXp
       default:
         return hiscore[`${(hiscoreType as string).toLowerCase()}xp` as keyof typeof hiscore] as number
     }
@@ -78,28 +84,27 @@ const HiscoresTable = (props: HiscoresTableProps) => {
             {isLoading || !hiscores ? (
               <HiscoresTableRowsSkeleton />
             ) : (
-              hiscores?.slice(startingRecord, endingRecord).map((hiscoreRow, index) => {
-                rank++
-                const rankToDisplay = startingRecord === 0 ? index + 1 : rank
+              hiscores?.slice(startingRecord, endingRecord).map(hiscoreRow => {
+                const rank = getRank(hiscoreRow)
 
                 return (
                   <HiscoresTableRow key={hiscoreRow.username}>
                     <HiscoreTableValueCell>
-                      {rankToDisplay === 1 ? (
+                      {rank === 1 ? (
                         <GoldBadge>1</GoldBadge>
-                      ) : rankToDisplay === 2 ? (
+                      ) : rank === 2 ? (
                         <SilverBadge>2</SilverBadge>
-                      ) : rankToDisplay === 3 ? (
+                      ) : rank === 3 ? (
                         <BronzeBadge>3</BronzeBadge>
                       ) : (
-                        <RankBadge>{rankToDisplay}</RankBadge>
+                        <RankBadge>{rank}</RankBadge>
                       )}
                     </HiscoreTableValueCell>
                     <HiscoreTableValueCell sx={{ display: 'flex', gap: '12px', alignItems: 'center' }}>
                       <HoverUnderlineLink href={`/hiscores/player/${hiscoreRow.username}`} sx={{ fontWeight: 500 }}>
                         {hiscoreRow.username}
                       </HoverUnderlineLink>
-                      {rankToDisplay === 1 ? <TopBadge>top</TopBadge> : null}
+                      {rank === 1 ? <TopBadge>top</TopBadge> : null}
                     </HiscoreTableValueCell>
                     <HiscoreTableValueCell>{getHiscoreValue(hiscoreRow)}</HiscoreTableValueCell>
                     <DesktopHiscoreTableCell>{convertExp(getHiscoreSkillXP(hiscoreRow))}</DesktopHiscoreTableCell>

--- a/src/components/organisms/PlayerHiscoreTable/PlayerHiscoreTable.styled.ts
+++ b/src/components/organisms/PlayerHiscoreTable/PlayerHiscoreTable.styled.ts
@@ -1,5 +1,5 @@
 import { HiscoreTableValueCell } from '@molecules/HiscoresTable/HiscoresTable.styled'
-import { TableCell, TableRow } from '@mui/material'
+import { TableRow } from '@mui/material'
 import { styled } from '@mui/material/styles'
 import { css } from '@mui/system'
 

--- a/src/components/organisms/PlayerHiscoreTable/PlayerHiscoreTable.styled.ts
+++ b/src/components/organisms/PlayerHiscoreTable/PlayerHiscoreTable.styled.ts
@@ -33,43 +33,10 @@ export const HiscoreTableRow = styled(TableRow, {
   `,
 )
 
-export const HiscoreSkillTableCell = styled(TableCell)(
-  ({ theme }) => css`
-    display: flex;
-    align-items: center;
-    border: 0;
-    padding: 8px;
-    gap: 8px;
-
-    ${theme.breakpoints.up('tablet')} {
-      padding: 16px;
-    }
-  `,
-)
-
 export const PlayerHiscoreTableCell = styled(HiscoreTableValueCell)(
   () => css`
     display: flex;
     align-items: center;
     gap: 10px;
-  `,
-)
-
-export const ExperienceCell = styled(HiscoreTableValueCell)(
-  ({ theme }) => css`
-    display: none;
-
-    ${theme.breakpoints.up('tablet')} {
-      display: table-cell;
-      min-width: 100px;
-    }
-  `,
-)
-
-export const MobileExperienceCell = styled(HiscoreTableValueCell)(
-  ({ theme }) => css`
-    ${theme.breakpoints.up('tablet')} {
-      display: none;
-    }
   `,
 )

--- a/src/globalTypes/Database/PlayerHiscoreDataRow.ts
+++ b/src/globalTypes/Database/PlayerHiscoreDataRow.ts
@@ -2,19 +2,42 @@ import { PlayerHiscoresSortField } from './PlayerHiscoresSortField'
 
 export type PlayerHiscoreDataRow = PlayerHiscoresSortField & {
   username: string
+  /** Login date in milliseconds since Unix epoch. */
   login_date: number
-  attack: number
-  defense: number
-  strength: number
+  overallRank: number
+  skill_total: number
+  totalXp: number
+  hitsRank: number
   hits: number
+  hitsxp: number
+  rangedRank: number
   ranged: number
+  rangedxp: number
+  prayerRank: number
   prayer: number
+  prayerxp: number
+  magicRank: number
   magic: number
+  magicxp: number
+  cookingRank: number
   cooking: number
+  cookingxp: number
+  woodcutRank: number
   woodcut: number
+  woodcutxp: number
+  fishingRank: number
   fishing: number
+  fishingxp: number
+  firemakingRank: number
   firemaking: number
+  firemakingxp: number
+  craftingRank: number
   crafting: number
+  craftingxp: number
+  smithingRank: number
   smithing: number
+  smithingxp: number
+  miningRank: number
   mining: number
+  miningxp: number
 }

--- a/src/hooks/useHiscores.ts
+++ b/src/hooks/useHiscores.ts
@@ -1,7 +1,7 @@
 import { PlayerHiscoreDataRow } from '@globalTypes/Database/PlayerHiscoreDataRow'
 import { HiscoreType } from '@globalTypes/Hiscores/HiscoreType'
 import { sendApiRequest } from '@utils/api/apiUtils'
-import { compareHiscores, isNotBaselineExp } from '@utils/hiscores/hiscoresUtils'
+import { isNotBaselineExp } from '@utils/hiscores/hiscoresUtils'
 import { Dispatch, SetStateAction, useEffect, useState } from 'react'
 
 /** Manages and provides state of player hiscore data records and sets loading status. */
@@ -22,10 +22,13 @@ const useHiscores = (hiscoreType: HiscoreType, setIsLoading: Dispatch<SetStateAc
   }, [])
 
   useEffect(() => {
+    const rankProp =
+      hiscoreType === 'Overall' ? 'overallRank' : (`${hiscoreType.toLowerCase()}Rank` as keyof PlayerHiscoreDataRow)
     const propName = hiscoreType === 'Overall' ? 'skill_total' : `${hiscoreType.toLowerCase()}xp`
+
     const sortedHiscores = rawHiscores
       ?.filter(hiscoreRow => isNotBaselineExp(hiscoreRow, propName))
-      .sort((hiscoreRow1, hiscoreRow2) => compareHiscores(hiscoreType, hiscoreRow1, hiscoreRow2))
+      .sort((a, b) => (a[rankProp] as number) - (b[rankProp] as number))
 
     setHiscores(sortedHiscores)
     setIsLoading(false)

--- a/src/pages/api/getPlayerHiscore/index.ts
+++ b/src/pages/api/getPlayerHiscore/index.ts
@@ -12,15 +12,54 @@ const handler = async (req: NextApiRequest, res: NextApiResponse<PlayerHiscoreDa
     return
   }
 
-  const query = `SELECT p.username, p.login_date, p.skill_total, e.attack AS 'attackxp', e.defense AS 'defensexp', 
-    e.strength AS 'strengthxp', ms.hits, e.hits AS 'hitsxp', ms.ranged, e.ranged AS 'rangedxp', ms.prayer, 
-    e.prayer AS 'prayerxp', ms.magic, e.magic AS 'magicxp', ms.cooking, e.cooking AS 'cookingxp', ms.woodcut, 
-    e.woodcut AS 'woodcutxp', ms.fishing, e.fishing AS 'fishingxp', ms.firemaking, e.firemaking AS 'firemakingxp', 
-    ms.crafting, e.crafting AS 'craftingxp', ms.smithing, e.smithing AS 'smithingxp', ms.mining, e.mining AS 'miningxp' 
-    FROM maxstats ms
-    JOIN players p ON p.id = ms.playerID JOIN experience e ON e.playerID = p.id WHERE p.group_id = 10 AND p.banned = 0`
+  const query = `
+    SELECT
+      p.username,
+      p.login_date,
+      r.overallRank,
+      p.skill_total,
+      (e.attack + e.defense + e.strength + e.hits + e.ranged + e.prayer + e.magic + e.cooking + e.woodcut + e.fishing + e.firemaking + e.crafting + e.smithing + e.mining) AS totalXp,
+      r.hitsRank,
+      ms.hits,
+      e.hits AS hitsxp,
+      r.rangedRank,
+      ms.ranged,
+      e.ranged AS rangedxp,
+      r.prayerRank,
+      ms.prayer,
+      e.prayer AS prayerxp,
+      r.magicRank,
+      ms.magic,
+      e.magic AS magicxp,
+      r.cookingRank,
+      ms.cooking,
+      e.cooking AS cookingxp,
+      r.woodcutRank,
+      ms.woodcut,
+      e.woodcut AS woodcutxp,
+      r.fishingRank,
+      ms.fishing,
+      e.fishing AS fishingxp,
+      r.firemakingRank,
+      ms.firemaking,
+      e.firemaking AS firemakingxp,
+      r.craftingRank,
+      ms.crafting,
+      e.crafting AS craftingxp,
+      r.smithingRank,
+      ms.smithing,
+      e.smithing AS smithingxp,
+      r.miningRank,
+      ms.mining,
+      e.mining AS miningxp
+    FROM players p
+    JOIN maxstats ms ON ms.playerID = p.id
+    JOIN experience e ON e.playerID = p.id
+    JOIN hiscore_ranks r ON r.playerID = p.id
+    WHERE p.username = ?;
+  `
 
-  return handleQuery('game', query, res)
+  return handleQuery('game', query, res, [username])
 }
 
 export default handler

--- a/src/pages/api/queryHiscores/index.ts
+++ b/src/pages/api/queryHiscores/index.ts
@@ -3,13 +3,51 @@ import { handleQuery } from '@utils/api/apiHandler'
 import { PlayerHiscoreDataRow } from '@globalTypes/Database/PlayerHiscoreDataRow'
 
 const handler = async (req: NextApiRequest, res: NextApiResponse<PlayerHiscoreDataRow>) => {
-  const query = `SELECT p.username, p.skill_total, e.attack AS 'attackxp', e.defense AS 'defensexp',
-  e.strength AS 'strengthxp', ms.hits, e.hits AS 'hitsxp', ms.ranged, e.ranged AS 'rangedxp', ms.prayer,
-  e.prayer AS 'prayerxp', ms.magic, e.magic AS 'magicxp', ms.cooking, e.cooking AS 'cookingxp', ms.woodcut,
-  e.woodcut AS 'woodcutxp', ms.fishing, e.fishing AS 'fishingxp', ms.firemaking, e.firemaking AS 'firemakingxp', ms.crafting,
-  e.crafting AS 'craftingxp', ms.smithing, e.smithing AS 'smithingxp', ms.mining,
-  e.mining AS 'miningxp' FROM maxstats ms JOIN players p ON p.id = ms.playerID
-  JOIN experience e ON e.playerID = p.id WHERE p.group_id = 10 AND p.banned = 0`
+  const query = `SELECT
+    p.username,
+    p.skill_total,
+    r.overallRank,
+    r.hitsRank,
+    r.rangedRank,
+    r.prayerRank,
+    r.magicRank,
+    r.cookingRank,
+    r.woodcutRank,
+    r.fishingRank,
+    r.firemakingRank,
+    r.craftingRank,
+    r.smithingRank,
+    r.miningRank,
+    (e.attack + e.defense + e.strength + e.hits + e.ranged + e.prayer + e.magic + e.cooking + e.woodcut + e.fishing + e.firemaking + e.crafting + e.smithing + e.mining) AS totalXp,
+    ms.hits,
+    e.hits AS hitsxp,
+    ms.ranged,
+    e.ranged AS rangedxp,
+    ms.prayer,
+    e.prayer AS prayerxp,
+    ms.magic,
+    e.magic AS magicxp,
+    ms.cooking,
+    e.cooking AS cookingxp,
+    ms.woodcut,
+    e.woodcut AS woodcutxp,
+    ms.fishing,
+    e.fishing AS fishingxp,
+    ms.firemaking,
+    e.firemaking AS firemakingxp,
+    ms.crafting,
+    e.crafting AS craftingxp,
+    ms.smithing,
+    e.smithing AS smithingxp,
+    ms.mining,
+    e.mining AS miningxp
+    FROM maxstats ms
+    JOIN players p ON p.id = ms.playerID
+    JOIN experience e ON e.playerID = p.id
+    JOIN hiscore_ranks r ON r.playerID = p.id
+    WHERE p.group_id = 10
+    AND p.banned = 0
+  `
 
   return handleQuery('game', query, res)
 }

--- a/src/pages/api/queryNpcHiscores/index.ts
+++ b/src/pages/api/queryNpcHiscores/index.ts
@@ -8,6 +8,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse<NpcHiscoreDataR
     FROM npckills nk
     JOIN players p ON nk.playerID = p.id
     WHERE p.banned = 0
+    AND p.group_id = 10
     ORDER BY killCount DESC
   `
 

--- a/src/pages/api/queryNpcHiscores/index.ts
+++ b/src/pages/api/queryNpcHiscores/index.ts
@@ -3,10 +3,13 @@ import { handleQuery } from '@utils/api/apiHandler'
 import { NpcHiscoreDataRow } from '@globalTypes/Database/NpcHiscoreDataRow'
 
 const handler = async (req: NextApiRequest, res: NextApiResponse<NpcHiscoreDataRow>) => {
-  const query = `SELECT p.username, nk.npcID, nk.killCount, p.login_date FROM npckills nk
+  const query = `
+    SELECT p.username, nk.npcID, nk.killCount, p.login_date 
+    FROM npckills nk
     JOIN players p ON nk.playerID = p.id
     WHERE p.banned = 0
-    ORDER BY killCount DESC`
+    ORDER BY killCount DESC
+  `
 
   return handleQuery('game', query, res)
 }

--- a/src/pages/hiscores/player/[accountName].tsx
+++ b/src/pages/hiscores/player/[accountName].tsx
@@ -4,164 +4,76 @@ import { ContentBlock } from '@atoms/ContentBlock'
 import { HiscoreTableHeaderCell } from '@molecules/HiscoresTable/HiscoresTable.styled'
 import { PageTabs } from '@atoms/PageTabs'
 import { Tab } from '@atoms/PageTabs/PageTabs.types'
-import { PlayerHiscoresRank } from '@atoms/PlayerHiscoresRank'
 import { PlayerHiscoreTable } from '@organisms/PlayerHiscoreTable'
-import {
-  ExperienceCell,
-  HiscoreSkillTableCell,
-  HiscoreTableRow,
-  MobileExperienceCell,
-  PlayerHiscoreTableCell,
-} from '@organisms/PlayerHiscoreTable/PlayerHiscoreTable.styled'
 import { PlayerHiscoreDataRow } from '@globalTypes/Database/PlayerHiscoreDataRow'
-import { PlayerHiscoresSortField } from '@globalTypes/Database/PlayerHiscoresSortField'
-import { HiscoreType } from '@globalTypes/Hiscores/HiscoreType'
-import { PlayerHiscoreRow } from '@globalTypes/Hiscores/PlayerHiscoreRow'
 import { getWebsiteBaseUrl } from '@utils/envUtils'
-import { compareHiscores, convertExp, getTotalExp, isNotBaselineExp } from '@utils/hiscores/hiscoresUtils'
 import { renderHead } from '@utils/renderUtils'
 import { redirectTo } from '@utils/window'
 import { HiscoresTabs } from '@models/HiscoresTabs'
-import { HiscoreTabsContainer, LevelProgressBar, LevelProgressBarFill } from '@styledPages/hiscores.styled'
+import { HiscoreTabsContainer } from '@styledPages/hiscores.styled'
 import { GetServerSideProps } from 'next'
-import { useEffect, useState } from 'react'
 import { formatExp } from '@utils/string/stringUtils'
-import { HiscoreSkillEmoji } from '@atoms/HiscoreSkillEmoji'
-import { useRouter } from 'next/router'
 import { PlayerHiscoreTableRowsSkeleton } from '@atoms/PlayerHiscoreTableRowsSkeleton'
 import { PlayerHiscoreHeader } from '@molecules/PlayerHiscoreHeader'
 import { StatisticCardProps } from '@atoms/StatisticCard/StatisticCard.types'
+import { PlayerHiscoreTableRow } from '@atoms/PlayerHiscoreTableRow'
+import { convertExp } from '@utils/hiscores/hiscoresUtils'
 
 type PlayerHiscorePageProps = {
   accountName: string
-  hiscoresData: PlayerHiscoreDataRow[]
-  lastLoginMillis: number | undefined
+  /** A single record containing all data on the player. `null` if the player does not exist. */
+  playerHiscore: PlayerHiscoreDataRow | null
 }
 
-const PlayerHiscorePage = ({ accountName, hiscoresData, lastLoginMillis }: PlayerHiscorePageProps) => {
-  const [playerHiscores, setPlayerHiscores] = useState<PlayerHiscoreRow[] | undefined>()
-  const router = useRouter()
-  const overallHiscoreRecord = playerHiscores?.[0]
-
-  const getLevelProgressPercentage = (level: number, isTotal: boolean) => (isTotal ? 1 : level === 1 ? 0 : level / 99)
-
-  const isMatchingUser = (hiscoreDataRow: PlayerHiscoreDataRow) =>
-    hiscoreDataRow.username.toLowerCase() === accountName.toLowerCase()
-
-  const getRank = (hiscoreType: HiscoreType) => {
-    // Order hiscoresData by hiscoreType descending
-    const propName = hiscoreType === 'Overall' ? 'skill_total' : `${hiscoreType.toLowerCase()}xp`
-    const sortedHiscoresData = hiscoresData
-      ?.filter(hiscore => isNotBaselineExp(hiscore, propName))
-      .sort((obj1, obj2) => compareHiscores(hiscoreType, obj1, obj2))
-
-    // Then get the index of the current player in that sorted list (and if 0-based, add 1), that's the rank.
-    const rank = sortedHiscoresData?.findIndex(isMatchingUser)
-    if (rank === undefined) return 0
-
-    return rank + 1
-  }
-
-  const getLevel = (hiscoreType: HiscoreType) => {
-    const playerHiscore = hiscoresData?.find(isMatchingUser)
-    const propName = hiscoreType === 'Overall' ? 'skill_total' : hiscoreType.toLowerCase()
-
-    if (!playerHiscore) return 0
-
-    return playerHiscore[propName as keyof PlayerHiscoresSortField]
-  }
-
-  const getExp = (hiscoreType: HiscoreType) => {
-    const playerHiscore = hiscoresData?.find(isMatchingUser)
-
-    if (!playerHiscore) return '0'
-
-    if (hiscoreType === 'Overall') {
-      return convertExp(getTotalExp(playerHiscore))
-    }
-
-    return convertExp(playerHiscore[`${hiscoreType.toLowerCase()}xp` as keyof PlayerHiscoresSortField])
-  }
-
-  const getPlayerHiscoreRow = (hiscoreType: HiscoreType) => {
-    const exp = getExp(hiscoreType)
-
-    return {
-      skill: hiscoreType,
-      rank: exp === '0' ? 0 : getRank(hiscoreType),
-      level: getLevel(hiscoreType),
-      exp: getExp(hiscoreType),
-    }
-  }
-
+const PlayerHiscorePage = ({ accountName, playerHiscore }: PlayerHiscorePageProps) => {
   const handleSetActiveTab = (tab: Tab) => {
     if (tab.label === 'NPC Kills') {
       redirectTo(`/npc-hiscores/player/${accountName}`)
     }
   }
 
-  useEffect(() => {
-    if (!hiscoresData) return
-
-    const playerHiscoreRowArray: PlayerHiscoreRow[] = []
-    playerHiscoreRowArray.push(getPlayerHiscoreRow('Overall'))
-    playerHiscoreRowArray.push(getPlayerHiscoreRow('Hits'))
-    playerHiscoreRowArray.push(getPlayerHiscoreRow('Ranged'))
-    playerHiscoreRowArray.push(getPlayerHiscoreRow('Prayer'))
-    playerHiscoreRowArray.push(getPlayerHiscoreRow('Magic'))
-    playerHiscoreRowArray.push(getPlayerHiscoreRow('Cooking'))
-    playerHiscoreRowArray.push(getPlayerHiscoreRow('Woodcut'))
-    playerHiscoreRowArray.push(getPlayerHiscoreRow('Fishing'))
-    playerHiscoreRowArray.push(getPlayerHiscoreRow('Firemaking'))
-    playerHiscoreRowArray.push(getPlayerHiscoreRow('Crafting'))
-    playerHiscoreRowArray.push(getPlayerHiscoreRow('Smithing'))
-    playerHiscoreRowArray.push(getPlayerHiscoreRow('Mining'))
-
-    setPlayerHiscores(playerHiscoreRowArray)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hiscoresData])
-
-  const overallRank = overallHiscoreRecord?.rank
-  const skillTotal = overallHiscoreRecord?.level
-  const totalExp = overallHiscoreRecord?.exp
-  const totalExpShorthand = totalExp ? formatExp(totalExp) : ''
+  const totalExp = convertExp(playerHiscore?.totalXp || 0)
+  const totalExpShorthand = formatExp(totalExp)
 
   const statCards: StatisticCardProps[] = [
     {
       label: 'Overall rank',
-      children: `#${overallRank}`,
+      children: `#${playerHiscore?.overallRank || 0}`,
       footnote: 'of all players',
       isRank: true,
     },
     {
       label: 'Skill total',
-      children: skillTotal,
+      children: playerHiscore?.skill_total || 0,
       footnote: 'across 14 skills',
     },
     {
       label: 'Total exp',
       children: totalExpShorthand,
-      footnote: totalExp ? `${totalExp} xp` : '',
+      footnote: `${totalExp} xp`,
     },
   ]
 
   return (
     <>
-      {renderHead(`${accountName} | Player Hiscores`, `Skill rankings for ${accountName}.`)}
+      {renderHead(
+        `${typeof accountName !== 'string' || !playerHiscore ? 'Player Not Found' : accountName} | Player Hiscores`,
+        `Skill rankings for ${accountName}.`,
+      )}
       <ContentBlock>
         <HiscoreTabsContainer>
           <PageTabs tabs={HiscoresTabs} activeTab={HiscoresTabs[0]} setActiveTab={tab => handleSetActiveTab(tab)} />
         </HiscoreTabsContainer>
-        {typeof accountName !== 'string' || !hiscoresData?.find(isMatchingUser) ? (
+        {typeof accountName !== 'string' || !playerHiscore ? (
           <BodyText variant='body' bodyTextAlign='center'>
             No hiscore found for this player.
           </BodyText>
         ) : (
           <>
             <PlayerHiscoreHeader
-              isLoading={!playerHiscores}
+              isLoading={!playerHiscore}
               accountName={accountName}
-              lastLoginMillis={lastLoginMillis}
+              lastLoginMillis={playerHiscore.login_date ?? 0}
               statCards={statCards}
             />
             <PlayerHiscoreTable
@@ -175,36 +87,83 @@ const PlayerHiscorePage = ({ accountName, hiscoresData, lastLoginMillis }: Playe
                 </>
               }
               body={
-                !playerHiscores ? (
+                !playerHiscore ? (
                   <PlayerHiscoreTableRowsSkeleton />
                 ) : (
-                  playerHiscores.map(playerHiscoreRow => (
-                    <HiscoreTableRow
-                      key={playerHiscoreRow.skill}
-                      onClick={() => router.push(`/hiscores?skill=${playerHiscoreRow.skill}`)}
-                    >
-                      <HiscoreSkillTableCell sx={{ fontWeight: 500 }}>
-                        <HiscoreSkillEmoji skill={playerHiscoreRow.skill} />
-                        {playerHiscoreRow.skill}
-                      </HiscoreSkillTableCell>
-                      <PlayerHiscoreTableCell>
-                        <PlayerHiscoresRank rank={playerHiscoreRow.rank} />
-                      </PlayerHiscoreTableCell>
-                      <PlayerHiscoreTableCell sx={{ fontWeight: 500 }}>
-                        <span>{playerHiscoreRow.level}</span>
-                        <LevelProgressBar>
-                          <LevelProgressBarFill
-                            completed={getLevelProgressPercentage(
-                              playerHiscoreRow.level,
-                              playerHiscoreRow.skill === 'Overall',
-                            )}
-                          />
-                        </LevelProgressBar>
-                      </PlayerHiscoreTableCell>
-                      <ExperienceCell>{playerHiscoreRow.exp}</ExperienceCell>
-                      <MobileExperienceCell>{formatExp(playerHiscoreRow.exp)}</MobileExperienceCell>
-                    </HiscoreTableRow>
-                  ))
+                  <>
+                    <PlayerHiscoreTableRow
+                      skill='Overall'
+                      rank={playerHiscore.overallRank}
+                      level={playerHiscore.skill_total}
+                      exp={playerHiscore.totalXp}
+                    />
+                    <PlayerHiscoreTableRow
+                      skill='Hits'
+                      rank={playerHiscore.hitsRank}
+                      level={playerHiscore.hits}
+                      exp={playerHiscore.hitsxp}
+                    />
+                    <PlayerHiscoreTableRow
+                      skill='Ranged'
+                      rank={playerHiscore.rangedRank}
+                      level={playerHiscore.ranged}
+                      exp={playerHiscore.rangedxp}
+                    />
+                    <PlayerHiscoreTableRow
+                      skill='Prayer'
+                      rank={playerHiscore.prayerRank}
+                      level={playerHiscore.prayer}
+                      exp={playerHiscore.prayerxp}
+                    />
+                    <PlayerHiscoreTableRow
+                      skill='Magic'
+                      rank={playerHiscore.magicRank}
+                      level={playerHiscore.magic}
+                      exp={playerHiscore.magicxp}
+                    />
+                    <PlayerHiscoreTableRow
+                      skill='Cooking'
+                      rank={playerHiscore.cookingRank}
+                      level={playerHiscore.cooking}
+                      exp={playerHiscore.cookingxp}
+                    />
+                    <PlayerHiscoreTableRow
+                      skill='Woodcut'
+                      rank={playerHiscore.woodcutRank}
+                      level={playerHiscore.woodcut}
+                      exp={playerHiscore.woodcutxp}
+                    />
+                    <PlayerHiscoreTableRow
+                      skill='Fishing'
+                      rank={playerHiscore.fishingRank}
+                      level={playerHiscore.fishing}
+                      exp={playerHiscore.fishingxp}
+                    />
+                    <PlayerHiscoreTableRow
+                      skill='Firemaking'
+                      rank={playerHiscore.firemakingRank}
+                      level={playerHiscore.firemaking}
+                      exp={playerHiscore.firemakingxp}
+                    />
+                    <PlayerHiscoreTableRow
+                      skill='Crafting'
+                      rank={playerHiscore.craftingRank}
+                      level={playerHiscore.crafting}
+                      exp={playerHiscore.craftingxp}
+                    />
+                    <PlayerHiscoreTableRow
+                      skill='Smithing'
+                      rank={playerHiscore.smithingRank}
+                      level={playerHiscore.smithing}
+                      exp={playerHiscore.smithingxp}
+                    />
+                    <PlayerHiscoreTableRow
+                      skill='Mining'
+                      rank={playerHiscore.miningRank}
+                      level={playerHiscore.mining}
+                      exp={playerHiscore.miningxp}
+                    />
+                  </>
                 )
               }
             />
@@ -224,27 +183,23 @@ export const getServerSideProps: GetServerSideProps = async ({ params }) => {
   const fetchBody = { username: accountName.toLowerCase() }
 
   const response = await fetch(fetchUrl, { method: 'POST', body: JSON.stringify(fetchBody) })
-  const output = await response.json()
+  const output: PlayerHiscoreDataRow[] = await response.json()
+  console.log('output', output)
 
-  if (output) {
-    const hiscores: PlayerHiscoreDataRow[] = output
-
-    // Get player last login date as a millis number.
-    // A value of 0 for millis means the user has never logged in. Likewise for undefined.
-    const lastLoginMillis = hiscores.find(
-      (row: PlayerHiscoreDataRow) => row.username.toLowerCase() === accountName.toLowerCase(),
-    )?.login_date
-
+  if (output && Array.isArray(output) && output.length > 0) {
     return {
       props: {
         accountName,
-        hiscoresData: hiscores,
-        lastLoginMillis: lastLoginMillis ?? 0,
+        playerHiscore: output[0],
       },
     }
-  }
-
-  return {
-    notFound: true,
+  } else {
+    // An empty `output` array usually means the player does not exist, so we need to return null
+    return {
+      props: {
+        accountName,
+        playerHiscore: null,
+      },
+    }
   }
 }

--- a/src/pages/hiscores/player/[accountName].tsx
+++ b/src/pages/hiscores/player/[accountName].tsx
@@ -184,7 +184,6 @@ export const getServerSideProps: GetServerSideProps = async ({ params }) => {
 
   const response = await fetch(fetchUrl, { method: 'POST', body: JSON.stringify(fetchBody) })
   const output: PlayerHiscoreDataRow[] = await response.json()
-  console.log('output', output)
 
   if (output && Array.isArray(output) && output.length > 0) {
     return {

--- a/src/styledPages/hiscores.styled.ts
+++ b/src/styledPages/hiscores.styled.ts
@@ -45,33 +45,6 @@ export const HiscoreTabsContainer = styled('div')(
   `,
 )
 
-export const LevelProgressBar = styled('div')(
-  ({ theme }) => css`
-    display: none;
-
-    ${theme.breakpoints.up('tablet')} {
-      display: block;
-      flex: 1;
-      height: 4px;
-      background-color: ${theme.palette.custom.levelProgressBg};
-      border-radius: 2px;
-      overflow: hidden;
-      max-width: 80px;
-    }
-  `,
-)
-
-export const LevelProgressBarFill = styled('div', {
-  shouldForwardProp: prop => prop !== 'completed',
-})<{ completed?: number }>(
-  ({ theme, completed }) => css`
-    background-color: ${theme.palette.primary.main};
-    height: 100%;
-    border-radius: 2px;
-    width: ${completed ? completed * 100 : 0}%;
-  `,
-)
-
 export const DesktopHiscoreTableCell = styled(HiscoreTableValueCell)(
   ({ theme }) => css`
     display: none;

--- a/src/utils/hiscores/hiscoresUtils.ts
+++ b/src/utils/hiscores/hiscoresUtils.ts
@@ -1,24 +1,8 @@
 import { NpcHiscoreDataRow } from '@globalTypes/Database/NpcHiscoreDataRow'
 import { PlayerHiscoreDataRow } from '@globalTypes/Database/PlayerHiscoreDataRow'
 import { PlayerHiscoresSortField } from '@globalTypes/Database/PlayerHiscoresSortField'
-import { HiscoreType, NpcHiscoreType, NpcHiscoreTypes } from '@globalTypes/Hiscores/HiscoreType'
+import { NpcHiscoreType, NpcHiscoreTypes } from '@globalTypes/Hiscores/HiscoreType'
 import { groupArrayByProperty } from '@utils/arrayUtils'
-
-export const getTotalExp = (hiscoreRow: PlayerHiscoreDataRow) =>
-  hiscoreRow.attackxp +
-  hiscoreRow.defensexp +
-  hiscoreRow.strengthxp +
-  hiscoreRow.hitsxp +
-  hiscoreRow.rangedxp +
-  hiscoreRow.prayerxp +
-  hiscoreRow.magicxp +
-  hiscoreRow.cookingxp +
-  hiscoreRow.woodcutxp +
-  hiscoreRow.fishingxp +
-  hiscoreRow.firemakingxp +
-  hiscoreRow.craftingxp +
-  hiscoreRow.smithingxp +
-  hiscoreRow.miningxp
 
 export const convertExp = (skillXP: number) => {
   // Open RSC Core Framework experience numbers are 4 times what the actual RS exp number is.
@@ -27,51 +11,12 @@ export const convertExp = (skillXP: number) => {
 
 export const isNotBaselineExp = (hiscore: PlayerHiscoreDataRow, propName: string) => {
   if (propName === 'skill_total') {
-    return getTotalExp(hiscore) > 4000
+    return hiscore.totalXp > 4000
   } else if (propName === 'hitsxp') {
     return hiscore.hitsxp > 4000
   } else {
     return hiscore[propName as keyof PlayerHiscoresSortField] > 0
   }
-}
-
-export const compareHiscores = (
-  hiscoreType: HiscoreType,
-  playerOne: PlayerHiscoreDataRow,
-  playerTwo: PlayerHiscoreDataRow,
-) => {
-  type HiscoreSortKey = keyof PlayerHiscoresSortField
-  let fieldName: HiscoreSortKey
-
-  switch (hiscoreType) {
-    case 'Overall':
-      fieldName = 'skill_total'
-      break
-    default:
-      fieldName = `${hiscoreType.toLowerCase()}xp` as HiscoreSortKey
-      break
-  }
-
-  if (playerOne[fieldName] > playerTwo[fieldName]) {
-    return -1
-  }
-
-  if (playerOne[fieldName] < playerTwo[fieldName]) {
-    return 1
-  }
-
-  if (playerOne[fieldName] === playerTwo[fieldName] && fieldName === 'skill_total') {
-    // If this is Overall, we need to compare total EXP and give the tie breaker to the player with more EXP.
-    if (getTotalExp(playerOne) > getTotalExp(playerTwo)) {
-      return -1
-    }
-
-    if (getTotalExp(playerOne) < getTotalExp(playerTwo)) {
-      return 1
-    }
-  }
-
-  return 0
 }
 
 /** Compares NPC hiscores by kill count. */


### PR DESCRIPTION
# What's Changed

- Fixed bug with hiscores pagination not appearing on desktop and tablet
- Fixed bug with admin and mod accounts showing in NPC hiscores
- Fixed Hiscore detail pages (player-specific) so they only fetch the data they need to instead of all hiscores, thanks to a new `hiscore_ranks` computed table in MySQL that is updated every minute with up to date ranks (_this table only includes data for normal, unbanned users_)
- Updated hiscores listing page to use the new `hiscore_ranks` table as well for computing ranks, instead of computing them in the front-end
