### PR TITLE
F2P-236 | Upgrade iron-session to V7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "eslint": "^8.1.0",
         "eslint-config-next": "13.1.6",
         "html-react-parser": "^6.1.1",
-        "iron-session": "^6.3.1",
+        "iron-session": "^7.0.6",
         "jest": "^29.5.0",
         "lucide-react": "^1.14.0",
         "next": "^16.2.6",
@@ -4181,13 +4181,13 @@
       "license": "MIT"
     },
     "node_modules/@peculiar/asn1-schema": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.7.0.tgz",
-      "integrity": "sha512-W8ZfWzLmQnrcky+eh3tni4IozMdqBDiHWU0N+vve/UGjMaUs8c0L7A2oEdkBXS8rTpWDpK/aoI3DG/L/hxmxPg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz",
+      "integrity": "sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==",
       "license": "MIT",
       "dependencies": {
         "@peculiar/utils": "^2.0.2",
-        "asn1js": "^3.0.6",
+        "asn1js": "^3.0.10",
         "tslib": "^2.8.1"
       }
     },
@@ -6560,15 +6560,6 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@types/accepts": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.7.tgz",
-      "integrity": "sha512-Pay9fq2lM2wXPWbteBsRAGiWH2hig4ZE2asK+mm7kUzlxRTfL961rj89I6zV/E3PcIkDqyuBEcMxFT7rccugeQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/aws-lambda": {
       "version": "8.10.161",
       "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.161.tgz",
@@ -6648,29 +6639,11 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/content-disposition": {
-      "version": "0.5.9",
-      "resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.9.tgz",
-      "integrity": "sha512-8uYXI3Gw35MhiVYhG3s295oihrxRyytcRHjSjqnqZVDDy/xcGBRny7+Xj1Wgfhv5QzRtN2hB2dVRBUX9XW3UcQ==",
-      "license": "MIT"
-    },
     "node_modules/@types/cookie": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.5.4.tgz",
       "integrity": "sha512-7z/eR6O859gyWIAjuvBWFzNURmf2oPBmJlfVWkwehU5nzIyjwBsTh7WMmEEV4JFnHuQ3ex4oyTvfKzcyJVDBNA==",
       "license": "MIT"
-    },
-    "node_modules/@types/cookies": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.9.2.tgz",
-      "integrity": "sha512-1AvkDdZM2dbyFybL4fxpuNCaWyv//0AwsuUk2DWeXyM1/5ZKm6W3z6mQi24RZ4l2ucY+bkSHzbDVpySqPGuV8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/connect": "*",
-        "@types/express": "*",
-        "@types/keygrip": "*",
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/debug": {
       "version": "4.1.13",
@@ -6738,12 +6711,6 @@
         "@types/unist": "*"
       }
     },
-    "node_modules/@types/http-assert": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/@types/http-assert/-/http-assert-1.5.6.tgz",
-      "integrity": "sha512-TTEwmtjgVbYAzZYWyeHPrrtWnfVkm8tQkP8P21uQifPgMRgjrow3XDEYqucuC8SKZJT7pUnhU/JymvjggxO9vw==",
-      "license": "MIT"
-    },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
@@ -6805,37 +6772,6 @@
       "dependencies": {
         "@types/ms": "*",
         "@types/node": "*"
-      }
-    },
-    "node_modules/@types/keygrip": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.6.tgz",
-      "integrity": "sha512-lZuNAY9xeJt7Bx4t4dx0rYCDqGPW8RXhQZK1td7d4H6E9zYbLoOtjBvfwdTKpsyxQI/2jv+armjX/RW+ZNpXOQ==",
-      "license": "MIT"
-    },
-    "node_modules/@types/koa": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.15.1.tgz",
-      "integrity": "sha512-aec2WUXXqYGkRAoofpAGdugxmVBrYuH4FFN/kw8eA8n5GSngOGJE1VU7nqew26fLAPi4eo07H/HtXVNUui8tPQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/accepts": "*",
-        "@types/content-disposition": "*",
-        "@types/cookies": "*",
-        "@types/http-assert": "*",
-        "@types/http-errors": "*",
-        "@types/keygrip": "*",
-        "@types/koa-compose": "*",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/koa-compose": {
-      "version": "3.2.9",
-      "resolved": "https://registry.npmjs.org/@types/koa-compose/-/koa-compose-3.2.9.tgz",
-      "integrity": "sha512-BroAZ9FTvPiCy0Pi8tjD1OfJ7bgU1gQf0eR6e1Vm+JJATy9eKOG3hQMFtMciMawiSOVnLMdmUOC46s7HBhSTsA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/koa": "*"
       }
     },
     "node_modules/@types/mdast": {
@@ -8830,9 +8766,9 @@
       "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -10395,15 +10331,6 @@
         "express": ">= 4.11"
       }
     },
-    "node_modules/express/node_modules/cookie": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/express/node_modules/mime-db": {
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
@@ -11530,32 +11457,26 @@
       }
     },
     "node_modules/iron-session": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/iron-session/-/iron-session-6.3.1.tgz",
-      "integrity": "sha512-3UJ7y2vk/WomAtEySmPgM6qtYF1cZ3tXuWX5GsVX4PJXAcs5y/sV9HuSfpjKS6HkTL/OhZcTDWJNLZ7w+Erx3A==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/iron-session/-/iron-session-7.0.6.tgz",
+      "integrity": "sha512-6CNbVdOF1qJCnj4ZLc23pJTbiCBoB2GmYQZeWPtN66KoJ3XauaKDMoea+MlrUxcMXcy52hQXTFpk5WhWDGU1CA==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/webcrypto": "^1.4.0",
         "@types/cookie": "^0.5.1",
         "@types/express": "^4.17.13",
-        "@types/koa": "^2.13.5",
-        "@types/node": "^17.0.41",
+        "@types/node": "^16.11.7",
         "cookie": "^0.5.0",
-        "iron-webcrypto": "^0.2.5"
+        "iron-webcrypto-vvo": "^0.0.2"
       },
       "engines": {
         "node": ">=12"
       },
       "peerDependencies": {
         "express": ">=4",
-        "koa": ">=2",
         "next": ">=10"
       },
       "peerDependenciesMeta": {
         "express": {
-          "optional": true
-        },
-        "koa": {
           "optional": true
         },
         "next": {
@@ -11564,21 +11485,31 @@
       }
     },
     "node_modules/iron-session/node_modules/@types/node": {
-      "version": "17.0.45",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
-      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
+      "version": "16.18.126",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
+      "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
       "license": "MIT"
     },
-    "node_modules/iron-webcrypto": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-0.2.8.tgz",
-      "integrity": "sha512-YPdCvjFMOBjXaYuDj5tiHst5CEk6Xw84Jo8Y2+jzhMceclAnb3+vNPP/CTtb5fO2ZEuXEaO4N+w62Vfko757KA==",
+    "node_modules/iron-session/node_modules/cookie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/iron-webcrypto-vvo": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/iron-webcrypto-vvo/-/iron-webcrypto-vvo-0.0.2.tgz",
+      "integrity": "sha512-+vP9rEUAslyUVc96h4fJdk++zvn9hoiNKOMOaLB/PslCxlSs96fe0dwcjQSir2mi0n42RHB4vYoiIMEZ2T+4hg==",
       "license": "MIT",
       "dependencies": {
+        "@peculiar/webcrypto": "^1",
         "buffer": "^6"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/brc-dd"
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-alphabetical": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "eslint": "^8.1.0",
     "eslint-config-next": "13.1.6",
     "html-react-parser": "^6.1.1",
-    "iron-session": "^6.3.1",
+    "iron-session": "^7.0.6",
     "jest": "^29.5.0",
     "lucide-react": "^1.14.0",
     "next": "^16.2.6",


### PR DESCRIPTION
# What's Changed

- Trying to upgrade `iron-session` to V7 to resolve the `Named export 'Crypto' not found` error without rewriting iron-session in the codebase (may need to upgrade to V8 and migrate codebase)
