### PR TITLE
F2P-236 | Fix html-react-parser (hopefully)

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  transpilePackages: ['html-react-parser', 'domhandler', 'htmlparser2'],
   async headers() {
     return [
       {


### PR DESCRIPTION
# What's Changed

- Added `html-react-parser` to `transpilePackages` in next config as a potential solve for a prod-only ESM error