### PR TITLE
F2P-240 | Tailwind / CSS Cleanup, Nav Z-Index Fix, Hall of Fame Linking Fix

### DIFF
--- a/src/components/atoms/CommunityAchievementsTable/CommunityAchievementsTable.tsx
+++ b/src/components/atoms/CommunityAchievementsTable/CommunityAchievementsTable.tsx
@@ -4,10 +4,10 @@ import { StandardLink } from '@atoms/StandardLink'
 import clsx from 'clsx'
 
 const CommunityAchievementsTable = () => {
-  const rowClass = 'grid grid-cols-[1fr_1fr_1fr] md:grid-cols-[45%_35%_20%] overflow-hidden'
+  const rowClass = 'grid grid-cols-3 md:grid-cols-[45%_35%_20%] overflow-hidden'
   const cellClass = clsx(
     'text-left p-4 font-normal text-neutral-100 border-stone-950',
-    'text-sm md:text-[18px] wrap-break-word min-w-0',
+    'text-sm md:text-lg wrap-break-word min-w-0',
   )
 
   return (
@@ -30,7 +30,6 @@ const CommunityAchievementsTable = () => {
                 <StandardLink
                   href={`/hiscores/player/${achievement.playerName}`}
                   hoverUnderline
-                  target='_blank'
                   className='text-amber-400 hover:text-yellow-700'
                 >
                   {achievement.playerName}

--- a/src/components/atoms/HiscoreSkillEmoji/HiscoreSkillEmoji.tsx
+++ b/src/components/atoms/HiscoreSkillEmoji/HiscoreSkillEmoji.tsx
@@ -34,7 +34,7 @@ const HiscoreSkillEmoji = (props: HiscoreSkillEmojiProps) => {
     }
   }
 
-  return <span className='flex items-center text-[16px] leading-none'>{getEmojiBySkill()}</span>
+  return <span className='flex items-center text-base leading-none'>{getEmojiBySkill()}</span>
 }
 
 export default HiscoreSkillEmoji

--- a/src/components/atoms/HiscoresControls/HiscoresControls.tsx
+++ b/src/components/atoms/HiscoresControls/HiscoresControls.tsx
@@ -58,7 +58,7 @@ const HiscoresControls = (props: HiscoresControlsProps) => {
                     handleClick(pageNum)
                   }}
                   className={clsx(
-                    'font-sans text-[14px]',
+                    'font-sans text-sm',
                     pageNum === currentPage && 'bg-primary-main hover:bg-primary-dark text-white',
                   )}
                 >

--- a/src/components/atoms/HiscoresMenuItem/HiscoresMenuItem.tsx
+++ b/src/components/atoms/HiscoresMenuItem/HiscoresMenuItem.tsx
@@ -7,7 +7,7 @@ const HiscoresMenuItem = (props: HiscoresMenuItemProps) => {
   const { menuItemLabel, hiscoreType, buttonOnClick } = props
   const isSelected = hiscoreType === menuItemLabel
   const skillIconFileName = isSelected ? hiscoreType : menuItemLabel
-  const skillNameClass = 'text-[12px] leading-none md:text-[14px]'
+  const skillNameClass = 'text-xs leading-none md:text-sm'
 
   return (
     <li onClick={() => buttonOnClick(menuItemLabel)} className={hiscoresStyles.hiscoresMenuItem(isSelected)}>

--- a/src/components/atoms/MainNavigationDropdownItem/MainNavigationDropdownItem.tsx
+++ b/src/components/atoms/MainNavigationDropdownItem/MainNavigationDropdownItem.tsx
@@ -35,16 +35,19 @@ const MainNavigationDropdownItem = (props: MainNavigationDropdownItemProps) => {
         variant='ghost'
         onClick={handleClick}
         className={clsx(
-          'h-10.75 rounded-none p-2 text-[18px] font-normal',
+          'h-10.75 rounded-none p-2 text-lg font-normal md:h-auto',
           'hover:text-secondary-main hover:bg-transparent',
           isActive ? 'text-secondary-main' : 'text-white',
-          'md:h-auto',
         )}
       >
         {title}
       </Button>
       <div
-        className={clsx('absolute w-full', isDropdownVisible ? 'block' : 'hidden', 'lg:hidden lg:group-hover:block')}
+        className={clsx(
+          'absolute z-1 w-full',
+          isDropdownVisible ? 'block' : 'hidden',
+          'lg:hidden lg:group-hover:block',
+        )}
       >
         <ul className='m-0 list-none p-0'>
           {subItems.map(subItem => (
@@ -53,7 +56,7 @@ const MainNavigationDropdownItem = (props: MainNavigationDropdownItemProps) => {
                 href={subItem.path}
                 target={subItem.opensInNewTab ? '_blank' : '_self'}
                 onClick={handleSubItemClick}
-                className='hover:text-nav-link-hover block p-2 text-[16px] text-white no-underline'
+                className='hover:text-nav-link-hover block p-2 text-base text-white no-underline'
               >
                 {subItem.text}
               </Link>

--- a/src/components/atoms/NpcPlayerHiscoreFilterBar/NpcPlayerHiscoreFilterBar.tsx
+++ b/src/components/atoms/NpcPlayerHiscoreFilterBar/NpcPlayerHiscoreFilterBar.tsx
@@ -31,7 +31,7 @@ const NpcPlayerHiscoreFilterBar = (props: NpcPlayerHiscoreFilterBarProps) => {
           className={clsx(
             'box-border h-8.5 w-full min-w-0 px-2 py-1.5',
             'border-divider rounded-md border-[0.5px]',
-            'text-primary-dark bg-background-paper text-[16px]',
+            'text-primary-dark bg-background-paper text-base',
             'font-sans outline-none',
             'md:px-2.5 md:py-1.75',
           )}
@@ -44,7 +44,7 @@ const NpcPlayerHiscoreFilterBar = (props: NpcPlayerHiscoreFilterBarProps) => {
               'absolute top-1/2 right-2 -translate-y-1/2',
               'cursor-pointer border-none bg-transparent p-0',
               'flex items-center justify-center',
-              'text-tertiary-text text-[16px] leading-none',
+              'text-tertiary-text text-base leading-none',
               'hover:text-primary-dark',
               '[-webkit-tap-highlight-color:transparent]',
             )}
@@ -59,7 +59,7 @@ const NpcPlayerHiscoreFilterBar = (props: NpcPlayerHiscoreFilterBarProps) => {
             key={filter}
             onClick={() => setActiveFilter(filter)}
             className={clsx(
-              'cursor-pointer rounded-md font-sans text-[14px] font-medium whitespace-nowrap',
+              'cursor-pointer rounded-md font-sans text-sm font-medium whitespace-nowrap',
               'border-[0.5px] px-2 py-1.25 md:px-2.5 md:py-1.5',
               activeFilter === filter
                 ? 'text-table-header-text bg-primary-main border-primary-main'

--- a/src/components/atoms/NpcPlayerHiscoreRows/NpcPlayerHiscoreRows.tsx
+++ b/src/components/atoms/NpcPlayerHiscoreRows/NpcPlayerHiscoreRows.tsx
@@ -23,11 +23,9 @@ const NpcPlayerHiscoreRows = (props: NpcPlayerHiscoreRowsProps) => {
           key={playerNpcHiscoreRow.npcName}
           onClick={() => router.push(`/npc-hiscores?npc=${playerNpcHiscoreRow.npcId}`)}
           className={clsx(
-            'grid grid-cols-[50%_20%_30%] text-[14px]',
+            'grid grid-cols-[50%_20%_30%] text-sm md:text-base',
             'border-divider h-fit items-center border-b-[0.5px]',
-            'last:border-b-0',
-            'hover:bg-divider cursor-pointer',
-            'md:text-[16px]',
+            'hover:bg-divider cursor-pointer last:border-b-0',
           )}
         >
           <td className={clsx(hiscoresStyles.hiscoresValueCellClass, 'font-medium')}>

--- a/src/components/atoms/PageTabs/PageTabs.tsx
+++ b/src/components/atoms/PageTabs/PageTabs.tsx
@@ -35,8 +35,7 @@ const PageTabs = (props: PageTabsProps) => {
             onClick={() => handleTabClick(tab)}
             style={fontSize ? { fontSize: `${fontSize}px` } : undefined}
             className={clsx(
-              'basis-full cursor-pointer p-2 font-sans text-[18px] font-medium',
-              'only:cursor-auto',
+              'basis-full cursor-pointer p-2 font-sans font-medium only:cursor-auto',
               isActive
                 ? cn('bg-primary-main text-table-header-text', activeTabClassName)
                 : cn(

--- a/src/components/atoms/PlayerHiscoreTableRow/PlayerHiscoreTableRow.tsx
+++ b/src/components/atoms/PlayerHiscoreTableRow/PlayerHiscoreTableRow.tsx
@@ -19,11 +19,9 @@ const PlayerHiscoreTableRow = (props: PlayerHiscoreTableRowProps) => {
     <tr
       onClick={() => router.push(`/hiscores?skill=${skill}`)}
       className={clsx(
-        'grid grid-cols-[30%_20%_20%_30%] text-[14px]',
+        'grid grid-cols-[30%_20%_20%_30%] text-sm md:text-base',
         'border-divider h-fit items-center border-b-[0.5px]',
-        'last:border-b-0',
-        'hover:bg-divider cursor-pointer',
-        'md:text-[16px]',
+        'hover:bg-divider cursor-pointer last:border-b-0',
       )}
     >
       <td className='flex items-center gap-2 border-0 p-2 font-medium md:p-4'>

--- a/src/components/atoms/PlayerHiscoresRank/PlayerHiscoresRank.tsx
+++ b/src/components/atoms/PlayerHiscoresRank/PlayerHiscoresRank.tsx
@@ -9,12 +9,12 @@ const PlayerHiscoresRank = (props: PlayerHiscoresRankProps) => {
       return <span className='text-tertiary-text'>{'--'}</span>
     case 1:
       return (
-        <span className='text-[16px]' title='#1'>
+        <span className='text-base' title='#1'>
           👑
         </span>
       )
     default:
-      return <span className='text-secondary-main text-[14px] font-semibold md:text-[16px]'>#{rank}</span>
+      return <span className='text-secondary-main text-sm font-semibold md:text-base'>#{rank}</span>
   }
 }
 

--- a/src/components/atoms/PlayerLookup/PlayerLookup.tsx
+++ b/src/components/atoms/PlayerLookup/PlayerLookup.tsx
@@ -28,7 +28,7 @@ const PlayerLookup = (props: PlayerLookupProps) => {
     <div
       className={clsx('bg-sidebar-bg border-divider rounded-lg border-[0.5px] p-3.5', 'md:basis-full lg:basis-auto')}
     >
-      <h3 className='text-left font-[Cinzel,serif] text-[16px] font-semibold'>Look Up Player</h3>
+      <h3 className='text-left text-base font-semibold'>Look Up Player</h3>
       <form onSubmit={handleSubmit} className='flex flex-wrap justify-center'>
         <Input
           required
@@ -39,7 +39,7 @@ const PlayerLookup = (props: PlayerLookupProps) => {
           value={playerName}
           className='bg-background-paper mt-2.5 w-full'
         />
-        <Button type='submit' className='mt-2.5 w-full text-[18px]'>
+        <Button type='submit' className='mt-2.5 w-full'>
           Search
         </Button>
       </form>

--- a/src/components/atoms/SectionDivider/SectionDivider.tsx
+++ b/src/components/atoms/SectionDivider/SectionDivider.tsx
@@ -9,7 +9,7 @@ const SectionDivider = (props: SectionDividerProps) => {
     <div
       className={clsx(
         'text-tertiary-text my-2.5 mb-2 flex items-center gap-1.5 py-1',
-        'text-[12px] whitespace-nowrap md:gap-2 md:py-1.5',
+        'text-xs whitespace-nowrap md:gap-2 md:py-1.5',
       )}
     >
       <span className='font-semibold tracking-[0.06em] uppercase'>{leftText}</span>

--- a/src/components/atoms/StatisticCard/StatisticCard.tsx
+++ b/src/components/atoms/StatisticCard/StatisticCard.tsx
@@ -8,9 +8,7 @@ const StatisticCard = (props: StatisticCardProps) => {
   return (
     <div className='text-tertiary-text bg-sidebar-bg flex flex-wrap rounded-lg px-3.5 py-2.5 text-left leading-tight'>
       <div className='mb-1 basis-full text-[11px] tracking-wider uppercase'>{label}</div>
-      <div
-        className={clsx('basis-full text-[20px] font-semibold', isRank ? 'text-secondary-main' : 'text-text-primary')}
-      >
+      <div className={clsx('basis-full text-xl font-semibold', isRank ? 'text-secondary-main' : 'text-text-primary')}>
         {children}
       </div>
       <div className='mt-0.5 basis-full text-[11px]'>{footnote}</div>

--- a/src/components/molecules/AccountWidget/AccountWidget.tsx
+++ b/src/components/molecules/AccountWidget/AccountWidget.tsx
@@ -27,10 +27,8 @@ const AccountWidget = (props: AccountWidgetProps) => {
     <div
       className={clsx(
         'flex items-center gap-2.5 font-sans font-normal',
-        'absolute top-2.5 right-2.5',
+        'absolute top-2.5 right-2.5 md:top-5 md:right-5 lg:text-xl',
         'text-foreground rounded-lg bg-white p-2.5',
-        'md:top-5 md:right-5',
-        'lg:text-xl',
       )}
     >
       {isLoggedIn && (

--- a/src/components/molecules/HiscoresMenu/HiscoresMenu.tsx
+++ b/src/components/molecules/HiscoresMenu/HiscoresMenu.tsx
@@ -14,7 +14,7 @@ const HiscoresMenu = (props: HiscoresMenuProps) => {
     <ul
       className={clsx(
         'bg-sidebar-bg border-divider list-none border-[0.5px] border-t-0',
-        'm-0 flex h-fit w-full gap-x-1.5 p-[10px_12px]',
+        'm-0 flex h-fit w-full gap-x-1.5 px-3 py-2.5',
         'overflow-x-auto [&::-webkit-scrollbar]:hidden',
         'md:block md:h-250 md:rounded-lg md:px-0 md:py-2',
         'md:border-t-divider md:gap-x-0 md:border-t-[0.5px]',

--- a/src/components/molecules/HiscoresTable/Badges.tsx
+++ b/src/components/molecules/HiscoresTable/Badges.tsx
@@ -1,9 +1,6 @@
 import clsx from 'clsx'
 
-const rankBadgeClass = clsx(
-  'size-5.5 text-[14px] font-semibold',
-  'rounded-full inline-flex items-center justify-center',
-)
+const rankBadgeClass = clsx('size-5.5 text-sm font-semibold', 'rounded-full inline-flex items-center justify-center')
 
 export const RankBadge = ({ children }: { children: React.ReactNode }) => (
   <span className={clsx(rankBadgeClass, 'text-text-secondary')}>{children}</span>

--- a/src/components/molecules/MainNavigation/MainNavigation.tsx
+++ b/src/components/molecules/MainNavigation/MainNavigation.tsx
@@ -3,6 +3,7 @@ import { NavigationItem } from './MainNavigation.types'
 import { MainNavigationDropdownItem } from '@atoms/MainNavigationDropdownItem'
 import Link from 'next/link'
 import { cn } from '@utils/cn'
+import clsx from 'clsx'
 
 const MainNavigation = () => {
   const { asPath } = useRouter()
@@ -79,7 +80,12 @@ const MainNavigation = () => {
 
   return (
     <div className='flex justify-center'>
-      <ul className='bg-dark-gray m-0 flex w-full list-none flex-wrap items-center justify-center gap-4 border-0 px-0! py-3! md:gap-8 md:border-2 md:border-solid md:border-black lg:flex-nowrap'>
+      <ul
+        className={clsx(
+          'bg-dark-gray m-0 flex w-full list-none flex-wrap items-center justify-center gap-4 border-0',
+          'py-3 md:gap-8 md:border-2 md:border-solid md:border-black lg:flex-nowrap',
+        )}
+      >
         {navigationItems.map((item: NavigationItem) => (
           <li key={item.path || item.subItems?.[0]?.path} className='flex items-center'>
             {item.path ? (

--- a/src/components/organisms/NewsPostForm/NewsPostForm.tsx
+++ b/src/components/organisms/NewsPostForm/NewsPostForm.tsx
@@ -119,7 +119,7 @@ const NewsPostForm = (props: NewsPostFormProps) => {
     <form onSubmit={handleSubmit} className='flex flex-wrap text-left'>
       <div className='flex w-full flex-wrap justify-start gap-2 text-left'>
         <label className='basis-full'>Image</label>
-        <span className='basis-full text-[14px] text-gray-500'>
+        <span className='basis-full text-sm text-gray-500'>
           Optional. If not provided, a placeholder image will be displayed next to the post.
         </span>
         <div className='flex basis-full gap-2'>

--- a/src/components/organisms/NpcHiscoresMenu/NpcHiscoresMenu.tsx
+++ b/src/components/organisms/NpcHiscoresMenu/NpcHiscoresMenu.tsx
@@ -16,7 +16,7 @@ const NpcHiscoresMenu = (props: NpcHiscoresMenuProps) => {
     >
       <ul
         className={clsx(
-          'm-0 flex h-fit w-full list-none gap-x-1.5 p-[10px_12px]',
+          'm-0 flex h-fit w-full list-none gap-x-1.5 px-3 py-2.5',
           'scrollbar-none overflow-x-auto [&::-webkit-scrollbar]:hidden',
           'md:block md:h-265 md:gap-x-0 md:px-0 md:py-2',
           'md:scrollbar-thin md:[scrollbar-color:var(--color-divider)_transparent] md:overflow-y-auto',

--- a/src/components/organisms/PlayerHiscoreTable/PlayerHiscoreTable.tsx
+++ b/src/components/organisms/PlayerHiscoreTable/PlayerHiscoreTable.tsx
@@ -26,7 +26,7 @@ const PlayerHiscoreTable = (props: HiscoreTableProps) => {
           <tr
             className={clsx(
               isNpcTable ? 'grid-cols-[50%_20%_30%]' : 'grid-cols-[30%_20%_20%_30%]',
-              'grid h-fit items-center border-b-0 text-[14px] md:text-[16px]',
+              'grid h-fit items-center border-b-0 text-sm md:text-base',
             )}
           >
             {columns}

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -40,7 +40,7 @@ function PaginationLink({ className, isActive, size = 'icon', ...props }: Pagina
       variant={isActive ? 'default' : 'ghost'}
       size={size}
       className={cn(
-        'size-9 rounded-md font-sans text-[14px]',
+        'size-9 rounded-md font-sans text-sm',
         isActive && 'bg-primary-main hover:bg-primary-dark text-white',
         className,
       )}

--- a/src/consts/styles/hiscores.ts
+++ b/src/consts/styles/hiscores.ts
@@ -1,21 +1,21 @@
 import clsx from 'clsx'
 
-const valueCellClass = 'text-left font-normal text-[14px] md:text-[16px] py-2.25 px-3.5 border-0'
+const valueCellClass = 'text-left font-normal text-sm md:text-base py-2.25 px-3.5 border-0'
 
 export const hiscoresStyles = {
   hiscoresTableRootContainerClass: 'flex w-full flex-wrap',
   hiscoresTableOuterContainerClass: 'w-full overflow-hidden rounded-t-lg shadow-none md:basis-full',
   hiscoresTableClass: 'bg-background-paper w-full rounded-lg font-sans',
   hiscoresTheadClass: 'bg-primary-main h-fit [&_tr]:border-b-0',
-  hiscoresListingTableRowClass: 'border-divider border-b-[0.5px] text-[14px] md:text-[16px]',
+  hiscoresListingTableRowClass: 'border-divider border-b-[0.5px] text-sm md:text-base',
   hiscoresValueCellClass: valueCellClass,
   hiscoresHeaderCellClass:
-    'text-left text-table-header-text border-0 px-3.5 py-2.25 text-[14px] leading-6 font-bold uppercase',
+    'text-left text-table-header-text border-0 px-3.5 py-2.25 text-sm leading-6 font-bold uppercase',
   hiscoresDesktopCellClass: clsx(valueCellClass, 'hidden md:table-cell'),
   hiscoresMobileCellClass: clsx(valueCellClass, 'md:hidden'),
   hiscoresMenuItem: (isSelected: boolean) =>
     clsx(
-      'flex cursor-pointer list-none items-center gap-1.25 text-center text-[14px]',
+      'flex cursor-pointer list-none items-center gap-1.25 text-center text-sm',
       'border-divider h-fit rounded-[20px] border-[0.5px] px-2.5 py-1.25 whitespace-nowrap',
       '-webkit-tap-highlight-color-transparent',
       isSelected

--- a/src/pages/account/index.tsx
+++ b/src/pages/account/index.tsx
@@ -81,7 +81,7 @@ const AccountPage = ({ user }: AccountPageProps) => {
             <>
               <hr className='my-5' />
               <div className='flex flex-wrap justify-center gap-5'>
-                <h2 className='text-center md:text-[48px]'>
+                <h2 className='text-center md:text-5xl'>
                   <span className='hidden md:inline'>🧰</span> Admin Tools <span className='hidden md:inline'>🧰</span>
                 </h2>
                 <BodyText bodyTextAlign='center'>

--- a/src/pages/how-to-play/index.tsx
+++ b/src/pages/how-to-play/index.tsx
@@ -10,7 +10,7 @@ import { StandardLink } from '@atoms/StandardLink'
 const HowToPlay = () => {
   const clientButtonClass = clsx(
     'flex w-66.5 font-bold justify-center items-center justify-self-center',
-    'border-[3px] border-transparent hover:border-[goldenrod] focus:border-[goldenrod]',
+    'border-3 border-transparent hover:border-[goldenrod] focus:border-[goldenrod]',
     'md:w-51.5 lg:w-66.5',
   )
   const clientImageClass = 'w-66.5 md:w-51.5 lg:w-66.5'

--- a/src/pages/npc-hiscores/index.tsx
+++ b/src/pages/npc-hiscores/index.tsx
@@ -63,8 +63,7 @@ const NpcHiscores = ({ hiscores, npcHiscoreType, npcSubTypes }: NpcHiscoresPageP
           <div className='w-full'>
             <h2
               className={clsx(
-                'text-text-primary mb-4 text-left text-[22px] leading-7 font-bold',
-                'md:mb-3 md:text-[28px] md:leading-9',
+                'text-text-primary mb-4 text-left text-[22px] leading-7 font-bold md:mb-3 md:text-[28px] md:leading-9',
               )}
             >
               {pageTitle}

--- a/src/theme/styles.css
+++ b/src/theme/styles.css
@@ -235,11 +235,11 @@
     }
 
     p:first-of-type {
-      margin-top: 0 !important;
+      margin-top: 0;
     }
 
     p:last-of-type {
-      margin-bottom: 0 !important;
+      margin-bottom: 0;
     }
 
     ul,
@@ -254,11 +254,11 @@
     }
 
     a {
-      color: var(--primary) !important;
+      color: var(--primary);
     }
 
     a:hover {
-      color: var(--secondary) !important;
+      color: var(--secondary);
     }
   }
 }


### PR DESCRIPTION
# What's Changed

- Cleaned up Tailwind classes and unnecessary important usage
- Fixed header nav z-index issue with dropdowns (page content was partially visible over nav dropdown on mobile, e.g. on homepage)
- Removed new tab functionality of Hall of Fame hiscore links
