### PR TITLE
F2P-58 | Pages shift horizontally on Windows when a modal is opened

### DIFF
--- a/src/components/molecules/RenameAccountModalBody/RenameAccountModalBody.tsx
+++ b/src/components/molecules/RenameAccountModalBody/RenameAccountModalBody.tsx
@@ -23,7 +23,7 @@ const RenameAccountModalBody = (props: RenameAccountModalBodyProps) => {
   if (playerRenamedMaximumAmount) {
     // # symbols are omitted since # is a special symbol added by the website to denote maximum rename attempts.
     return (
-      <>
+      <div className='flex flex-wrap gap-4'>
         <p>
           You have already renamed your character (<code>{account.username}</code>) once and changed it back once, so
           you cannot rename again. If you think this is a mistake, please contact the admin directly over Discord
@@ -32,13 +32,13 @@ const RenameAccountModalBody = (props: RenameAccountModalBodyProps) => {
         <p>
           Your previous name was <code>{account.former_name.replace('#', '')}</code>.
         </p>
-      </>
+      </div>
     )
   }
 
   if (playerRenamedOnce) {
     return (
-      <>
+      <div className='flex flex-wrap gap-4'>
         <strong>
           Please log <code>{account.username}</code> out of the game before continuing.
         </strong>{' '}
@@ -60,7 +60,7 @@ const RenameAccountModalBody = (props: RenameAccountModalBodyProps) => {
           </BodyText>
         )}
         {restoreErrorMessage && <FieldValidationMessage>{restoreErrorMessage}</FieldValidationMessage>}
-      </>
+      </div>
     )
   }
 

--- a/src/components/organisms/NewsPostForm/NewsPostForm.tsx
+++ b/src/components/organisms/NewsPostForm/NewsPostForm.tsx
@@ -153,7 +153,7 @@ const NewsPostForm = (props: NewsPostFormProps) => {
         onChange={handleBodyChange}
         value={bodyInput}
         required
-        className='mt-2.5 w-full'
+        className='mt-2.5 w-full break-all lg:break-normal'
       />
       <div className='hidden'>
         <ReactMarkdown className='news-post-body-markdown-html'>{bodyInput}</ReactMarkdown>
@@ -171,7 +171,10 @@ const NewsPostForm = (props: NewsPostFormProps) => {
           <>
             <h2 className='text-3xl'>{title}</h2>
             {bodyHtml && (
-              <div dangerouslySetInnerHTML={{ __html: bodyHtml }} className='news-post-detail-body text-base' />
+              <div
+                dangerouslySetInnerHTML={{ __html: bodyHtml }}
+                className='news-post-detail-body text-base break-all lg:break-normal'
+              />
             )}
           </>
         }

--- a/src/theme/styles.css
+++ b/src/theme/styles.css
@@ -184,6 +184,7 @@
   }
   html {
     @apply font-sans;
+    scrollbar-gutter: stable;
   }
   button {
     cursor: pointer;


### PR DESCRIPTION
# What's Changed

- Fixed content shift seen when opening modals (mostly on Windows?)
- Fixed mobile and tablet styling of news post form
- Improved spacing in rename account modal
