### PR TITLE
F2P-225 | Allow emojis in news posts

### DIFF
--- a/src/utils/db.ts
+++ b/src/utils/db.ts
@@ -11,6 +11,7 @@ const sqlServerSettings = {
   port,
   user: process.env.MARIADB_USER,
   password: process.env.MARIADB_PASSWORD,
+  charset: 'UTF8MB4_GENERAL_CI',
 }
 
 const gameDB = mysql({


### PR DESCRIPTION
# What's Changed

- Set SQL charset to `UTF8MB4_GENERAL_CI` so that emojis can be entered in news posts from the admin side and also appear correctly in posts

# Notes

There were also some changes made to the databases for this feature that this PR doesn't cover. These statements were executed:
  ```
  # enable emoji for newsposts 
ALTER DATABASE neatf2pwebsite CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

USE neatf2pwebsite;
ALTER TABLE newsposts CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

-- If you want to be extra sure the specific column picks it up:
ALTER TABLE newsposts 
  MODIFY body TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
  ```