### PR TITLE
F2P-243 | The login page STILL isn't showing errors when the database connection fails

### DIFF
--- a/src/pages/account/login/index.tsx
+++ b/src/pages/account/login/index.tsx
@@ -105,7 +105,11 @@ const AccountLoginPage = ({ user }: AccountLoginPageProps) => {
             setValidationError(`An error occurred logging you in: ${error?.response?.data}`)
           })
       })
-      .catch((error: string) => error)
+      .catch((error: { response: { data: string } }) => {
+        console.error(error?.response?.data)
+        setButtonDisabled(false)
+        setValidationError(`An error occurred logging you in: ${error?.response?.data}`)
+      })
   }
 
   return (

--- a/src/utils/api/apiUtils.ts
+++ b/src/utils/api/apiUtils.ts
@@ -86,7 +86,9 @@ export const handleForbiddenRedirect = (error: AxiosError<string>) => {
   }
 }
 
-/** Handles errors in API calls by logging the error and throwing a 500. */
+/** Handles errors in API calls by logging the error and throwing a 500.
+ * Note that the error is logged to the server, not the client (browser).
+ */
 export const handleError = <T>(res: NextApiResponse<T>, error: unknown, source: string) => {
   console.error(`An error occurred in the ${source} API handler: ${error}`)
   res.statusCode = 500


### PR DESCRIPTION
# What's Changed

- Added proper error handling and reporting if the `getUser` endpoint throws an exception from the login page
- Updated `handleError` docu-comment for clarity regarding where the error gets console logged to